### PR TITLE
Modify filepath of 'cover' to show cover image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1266,7 +1266,7 @@ function create()
 
   Book( title = @params(:book_title),
         author = @params(:book_author),
-        cover = cover_path) |> save && redirect_to(:get_bgbooks)
+        cover = "/" * cover_path) |> save && redirect_to(:get_bgbooks)
 end
 ```
 


### PR DESCRIPTION
I tried to show book covers according to Readme but they did not appear if without "/" ahead of path.
I added "/" to the relevant part in BooksController.create().