### PR TITLE
CORS changes to set_headers

### DIFF
--- a/src/AppServer.jl
+++ b/src/AppServer.jl
@@ -165,11 +165,8 @@ function set_headers!(req::HTTP.Request, res::HTTP.Response, app_response::HTTP.
   Combine headers. If different values for the same keys,
   use the following order of precedence:
   app_response > res
-
-  The vcat step is unnecessary, since it will allow duplicate keys, but these
-  shouldn't exist between app_response and the outcome of a merge where app_response has highest precedence.
   =#
-  app_response.headers = vcat(app_response.headers, [d for d in merge(Dict(res.headers), Dict(app_response.headers))]) |> unique
+  app_response.headers = [d for d in merge(Dict(res.headers), Dict(app_response.headers))]
 
   app_response
 end

--- a/src/AppServer.jl
+++ b/src/AppServer.jl
@@ -139,11 +139,16 @@ function set_headers!(req::HTTP.Request, res::HTTP.Response, app_response::HTTP.
   if req.method == Genie.Router.OPTIONS || req.method == Genie.Router.GET
     Genie.config.cors_headers["Access-Control-Allow-Origin"] = strip(Genie.config.cors_headers["Access-Control-Allow-Origin"])
 
+    #=
+    If the request origin matches an entry in the config's array of allowed origins,
+    and the CORS header allowed origin is set to "" or "*", then overwrite the
+    CORS header allowed origin with the request origin.
+    =#
     ! isempty(Genie.config.cors_allowed_origins) &&
-      in(req.headers["Origin"], Genie.config.cors_allowed_origins) &&
+      in(Dict(req.headers)["Origin"], Genie.config.cors_allowed_origins) &&
       (Genie.config.cors_headers["Access-Control-Allow-Origin"] == "" ||
         Genie.config.cors_headers["Access-Control-Allow-Origin"] == "*") &&
-      (Genie.config.cors_headers["Access-Control-Allow-Origin"] = req.headers["Origin"])
+      (Genie.config.cors_headers["Access-Control-Allow-Origin"] = Dict(req.headers)["Origin"])
 
     app_response.headers = [d for d in merge(Genie.config.cors_headers, Dict(res.headers))]
   end

--- a/src/AppServer.jl
+++ b/src/AppServer.jl
@@ -161,6 +161,14 @@ function set_headers!(req::HTTP.Request, res::HTTP.Response, app_response::HTTP.
     app_response.headers = [d for d in merge(Genie.config.cors_headers, Dict(res.headers), Dict(app_response.headers))]
   end
 
+  #=
+  Combine headers. If different values for the same keys,
+  use the following order of precedence:
+  app_response > res
+
+  The vcat step is unnecessary, since it will allow duplicate keys, but these
+  shouldn't exist between app_response and the outcome of a merge where app_response has highest precedence.
+  =#
   app_response.headers = vcat(app_response.headers, [d for d in merge(Dict(res.headers), Dict(app_response.headers))]) |> unique
 
   app_response

--- a/src/AppServer.jl
+++ b/src/AppServer.jl
@@ -150,7 +150,15 @@ function set_headers!(req::HTTP.Request, res::HTTP.Response, app_response::HTTP.
         Genie.config.cors_headers["Access-Control-Allow-Origin"] == "*") &&
       (Genie.config.cors_headers["Access-Control-Allow-Origin"] = Dict(req.headers)["Origin"])
 
-    app_response.headers = [d for d in merge(Genie.config.cors_headers, Dict(res.headers))]
+    #=
+    Combine headers. If different values for the same keys,
+    use the following order of precedence:
+    app_response > res > Genie.config
+
+    The app_response likely has an automatically-determined
+    response type header that we want to keep.
+    =#
+    app_response.headers = [d for d in merge(Genie.config.cors_headers, Dict(res.headers), Dict(app_response.headers))]
   end
 
   app_response.headers = vcat(app_response.headers, [d for d in merge(Dict(res.headers), Dict(app_response.headers))]) |> unique

--- a/src/AppServer.jl
+++ b/src/AppServer.jl
@@ -136,7 +136,7 @@ end
 Configures the response headers.
 """
 function set_headers!(req::HTTP.Request, res::HTTP.Response, app_response::HTTP.Response) :: HTTP.Response
-  if req.method == Genie.Router.OPTIONS
+  if req.method == Genie.Router.OPTIONS || req.method == Genie.Router.GET
     Genie.config.cors_headers["Access-Control-Allow-Origin"] = strip(Genie.config.cors_headers["Access-Control-Allow-Origin"])
 
     ! isempty(Genie.config.cors_allowed_origins) &&

--- a/src/AppServer.jl
+++ b/src/AppServer.jl
@@ -139,13 +139,12 @@ function set_headers!(req::HTTP.Request, res::HTTP.Response, app_response::HTTP.
   if req.method == Genie.Router.OPTIONS || req.method == Genie.Router.GET
 
     request_origin = Dict(req.headers)["Origin"]
-    allowed_origin = strip(Genie.config.cors_headers["Access-Control-Allow-Origin"])
 
-    if in(request_origin, Genie.config.cors_allowed_origins)
-      allowed_origin = request_origin
-    end
-
-    allowed_origin_dict = Dict("Access-Control-Allow-Origin" => allowed_origin)
+    allowed_origin_dict = Dict("Access-Control-Allow-Origin" =>
+      in(request_origin, Genie.config.cors_allowed_origins)
+      ? request_origin
+      : strip(Genie.config.cors_headers["Access-Control-Allow-Origin"])
+    )
 
     #=
     Combine headers. If different values for the same keys,


### PR DESCRIPTION
These changes are split into lots of smaller commits to clarify intent. CORS management could be further improved, but I wanted to discuss strategies before making additional changes.

I think it would be best to ensure that all [Simple HTTP Requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Simple_requests) at least respond with the correct `Access-Control-Allow-Origin` header, while minimizing unnecessary Access-Control header spam. `GET` is now producing more headers than necessary, so that could use more refinement. `POST` and `HEAD` can also be simple requests, but those are not yet supported in this change set. Is the simplest solution to just send `Access-Control-Allow-Origin` for all requests, even if the browser will get that header anyway from a preflight `OPTIONS` request if required (for example with `POST` `application/json` `Content-Type`)?

Wanted to also highlight some interesting unexpected behavior that this pull request addresses.
Consider the following scenario:

Initial conditions:
```
Genie.config.cors_allowed_origins = ["bar.com"]
Genie.config.cors_headers["Access-Control-Allow-Origin"] = "*" # will later refer to this as CORSACAO
```
- request from foo.com
    - Success, because CORSACAO = "*"
- request from bar.com
    - Success, because CORSACAO = "*"
    - set CORSACAO = "bar.com"
- request from foo.com
    - Fail, because CORSACAO is now "bar.com"
    - Likely confusing for users. "But foo.com was just working!?"