### PR TITLE
Update json 500 error responses for refactored JSON renderer

### DIFF
--- a/src/Router.jl
+++ b/src/Router.jl
@@ -1044,7 +1044,7 @@ end
 """
 function error_500(error_message::String = "", req::HTTP.Request = HTTP.Request("", "", ["Content-Type" => request_mappings[:html]])) :: HTTP.Response
   if request_type_is(req, :json)
-    HTTP.Response(500, ["Content-Type" => request_mappings[:json]], body = Flax.JSONRenderer.JSONParser.json(Dict("error" => "500 - $error_message")))
+    Renderer.Json.json(Dict("error" => "500 - $error_message"), status = 500)
   elseif request_type_is(req, :text)
     HTTP.Response(500, ["Content-Type" => request_mappings[:text]], body = "Error: 500 - $error_message")
   else
@@ -1057,7 +1057,7 @@ end
 """
 function error_xxx(error_message::String = "", req::HTTP.Request = HTTP.Request("", "", ["Content-Type" => request_mappings[:html]]); error_info::String = "", error_code::Int = 500) :: HTTP.Response
   if request_type_is(req, :json)
-    HTTP.Response(error_code, ["Content-Type" => request_mappings[:json]], body = Flax.JSONRenderer.JSONParser.json(Dict("error" => "500 - $error_message")))
+    Renderer.Json.json(Dict("error" => "500 - $error_message"), status = error_code)
   elseif request_type_is(req, :text)
     HTTP.Response(error_code, ["Content-Type" => request_mappings[:text]], body = "Error: 500 - $error_message")
   else

--- a/test/json-error/test.jl
+++ b/test/json-error/test.jl
@@ -1,0 +1,16 @@
+using Pkg
+pkg"activate ."
+
+using Genie, HTTP
+import Genie.Router: route, POST, @params
+import Genie.Requests: jsonpayload
+
+route("/json-error", method = POST) do
+  error("500, sorry")
+end
+
+Genie.AppServer.startup()
+
+@test_throws HTTP.ExceptionRequest.StatusError HTTP.request("POST", "http://localhost:8000/json-error", [("Content-Type", "application/json; charset=utf-8")], """{"greeting":"hello"}""")
+
+exit(0)


### PR DESCRIPTION
The following fails to return a json 500 error on master:
```
using Genie, HTTP
import Genie.Router: route, POST, @params
import Genie.Requests: jsonpayload

route("/json-error", method = POST) do
  error("500, sorry")
end

Genie.AppServer.startup()

HTTP.request("POST", "http://localhost:8000/json-error", [("Content-Type", "application/json; charset=utf-8")], """{"greeting":"hello"}""")
```

Instead, get EOF, due to an error in rendering the json error message. This is due to: `Flax` not defined in function `error_500`). I presume this is related to 2b58a09e6f03a1abd6e44fca224e4f1f69ba6d9f

This PR simply fixes up the error_500 and error_xxx functions to use the new location of the json renderer. Also adds a simple smoke test based on the example above to `test/json-error/test.jl` that just checks for a StatusError in response to the above request.