### PR TITLE
Update: Use the functional interface of Pkg

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
       - name: Install dependencies
-        run: julia -e 'using Pkg; Pkg.add(Pkg.PackageSpec(name = "CompatHelper", url = "https://github.com/bcbi/CompatHelper.jl.git"))'
+        run: julia -e 'using Pkg; Pkg.add(Pkg.PackageSpec(url="https://github.com/bcbi/CompatHelper.jl.git"))'
       - name: CompatHelper.main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           version: '1.3'
       - run: julia --project=docs -e '
           using Pkg;
-          Pkg.develop(PackageSpec(; path=pwd()));
+          Pkg.develop(PackageSpec(path=pwd()));
           Pkg.instantiate();'
       - run: julia --project=docs docs/make.jl
         env:

--- a/docs/documentation/10--Loading_Genie_Apps.md
+++ b/docs/documentation/10--Loading_Genie_Apps.md
@@ -57,7 +57,7 @@ We will need to make the local package environment available:
 
 ```julia
 using Pkg
-pkg"activate ."
+Pkg.activate(".")
 ```
 
 Then:

--- a/src/FileTemplates.jl
+++ b/src/FileTemplates.jl
@@ -110,7 +110,7 @@ function dockerfile(; user::String = "genie", supervisor::Bool = false, nginx::B
 
   USER $user
 
-  RUN julia -e "using Pkg; pkg\\"activate . \\"; pkg\\"instantiate\\"; pkg\\"precompile\\"; "
+  RUN julia -e "using Pkg; Pkg.activate(\\".\\"); Pkg.instantiate(); Pkg.precompile(); "
 
   # ports
   EXPOSE $port

--- a/src/Generator.jl
+++ b/src/Generator.jl
@@ -286,8 +286,8 @@ function write_app_custom_files(path::String, app_path::String) :: Nothing
     write(f,
     """
       cd(@__DIR__)
-      import Pkg
-      Pkg.pkg"activate ."
+      using Pkg
+      Pkg.activate(".")
 
       function main()
         include(joinpath("$(Genie.config.path_src)", "$(moduleinfo[1]).jl"))
@@ -306,11 +306,11 @@ Installs the application's dependencies using Julia's Pkg
 """
 function install_app_dependencies(app_path::String = "."; testmode::Bool = false) :: Nothing
   @info "Installing app dependencies"
-  Pkg.pkg"activate ."
+  Pkg.activate(".")
 
-  testmode ? Pkg.pkg"dev Genie" : Pkg.pkg"add Genie"
-  Pkg.pkg"add Revise"
-  Pkg.pkg"add LoggingExtras"
+  testmode ? Pkg.develop("Genie") : Pkg.add("Genie")
+  Pkg.add("Revise")
+  Pkg.add("LoggingExtras")
 
   nothing
 end

--- a/src/Generator.jl
+++ b/src/Generator.jl
@@ -286,7 +286,7 @@ function write_app_custom_files(path::String, app_path::String) :: Nothing
     write(f,
     """
       cd(@__DIR__)
-      using Pkg
+      import Pkg
       Pkg.activate(".")
 
       function main()

--- a/src/Plugins.jl
+++ b/src/Plugins.jl
@@ -92,8 +92,8 @@ function scaffold(plugin_name::String, dest::String = "."; force = false)
   @info "Adding dependencies"
 
   cd(dest)
-  Pkg.pkg"activate ."
-  Pkg.pkg"add https://github.com/genieframework/Genie.jl"
+  Pkg.activate(".")
+  Pkg.add(Pkg.PackageSpec(name="Genie", rev="master"))
 
   run(`git init`)
   run(`git add .`)

--- a/src/Plugins.jl
+++ b/src/Plugins.jl
@@ -93,7 +93,7 @@ function scaffold(plugin_name::String, dest::String = "."; force = false)
 
   cd(dest)
   Pkg.activate(".")
-  Pkg.add(Pkg.PackageSpec(name="Genie", rev="master"))
+  Pkg.add("Genie")
 
   run(`git init`)
   run(`git add .`)

--- a/test/fileuploads/test.jl
+++ b/test/fileuploads/test.jl
@@ -1,5 +1,5 @@
 using Pkg
-pkg"activate ."
+Pkg.activate(".")
 
 using Genie, Genie.Router, Genie.Renderer
 

--- a/test/getargsparse/test.jl
+++ b/test/getargsparse/test.jl
@@ -1,5 +1,5 @@
 using Pkg
-pkg"activate ."
+Pkg.activate(".")
 
 using Genie, Dates, HTTP
 import Genie.Router: route, POST, @params

--- a/test/headers/test.jl
+++ b/test/headers/test.jl
@@ -1,5 +1,5 @@
 using Pkg
-pkg"activate ."
+Pkg.activate(".")
 
 using Genie, HTTP
 using Genie.Router, Genie.Responses

--- a/test/hello/httptest.jl
+++ b/test/hello/httptest.jl
@@ -1,5 +1,5 @@
 using Pkg
-pkg"activate ."
+Pkg.activate(".")
 
 using HTTP, Sockets
 

--- a/test/hello/perftest.jl
+++ b/test/hello/perftest.jl
@@ -1,5 +1,5 @@
 using Pkg
-pkg"activate ."
+Pkg.activate(".")
 
 using Genie
 import Genie.Router: route

--- a/test/hello/test.jl
+++ b/test/hello/test.jl
@@ -1,5 +1,5 @@
 using Pkg
-pkg"activate ."
+Pkg.activate(".")
 
 using Genie, HTTP
 import Genie.Router: route

--- a/test/htmlrendering/test.jl
+++ b/test/htmlrendering/test.jl
@@ -1,5 +1,5 @@
 using Pkg
-pkg"activate ."
+Pkg.activate(".")
 
 using Genie, Genie.Router, Genie.Renderer
 

--- a/test/inlinecache/test.jl
+++ b/test/inlinecache/test.jl
@@ -1,5 +1,5 @@
 using Pkg
-pkg"activate ."
+Pkg.activate(".")
 
 using Revise
 Revise.track(@__FILE__)

--- a/test/json-error/test.jl
+++ b/test/json-error/test.jl
@@ -1,5 +1,5 @@
 using Pkg
-pkg"activate ."
+Pkg.activate(".")
 
 using Genie, HTTP
 import Genie.Router: route, POST, @params

--- a/test/jsonpayload/test.jl
+++ b/test/jsonpayload/test.jl
@@ -1,5 +1,5 @@
 using Pkg
-pkg"activate ."
+Pkg.activate(".")
 
 using Genie, HTTP
 import Genie.Router: route, POST, @params

--- a/test/optionsrequest/test.jl
+++ b/test/optionsrequest/test.jl
@@ -1,5 +1,5 @@
 using Pkg
-pkg"activate ."
+Pkg.activate(".")
 
 using Genie, HTTP
 using Genie.Router

--- a/test/postform/test.jl
+++ b/test/postform/test.jl
@@ -1,5 +1,5 @@
 using Pkg
-pkg"activate ."
+Pkg.activate(".")
 
 using Genie, Genie.Router, Genie.Renderer
 

--- a/test/responses/test.jl
+++ b/test/responses/test.jl
@@ -1,5 +1,5 @@
 using Pkg
-pkg"activate ."
+Pkg.activate(".")
 
 using Genie, HTTP
 using Genie.Router, Genie.Responses


### PR DESCRIPTION
Pkg docs say: [1](https://julialang.github.io/Pkg.jl/dev/api/) [2](https://julialang.github.io/Pkg.jl/dev/repl/)
```
The function API is recommended for non-interactive usage, for example in scripts.
```
```
The REPL mode is mostly meant for interactive use, and for non-interactive use it is recommended to use the "API mode"
```