### PR TITLE
Not all exceptions have field msg

### DIFF
--- a/src/Router.jl
+++ b/src/Router.jl
@@ -538,7 +538,7 @@ function match_channels(req, msg::String, ws_client, params::Params) :: String
 
                 result
               catch ex
-                isa(ex, Exception) ? ex.msg : rethrow(ex)
+                isa(ex, Exception) ? sprint(showerror, ex) : rethrow(ex)
               end
   end
 


### PR DESCRIPTION
Replace `ex.msg` with `sprint(showerror, ex)`. Not all `<:Exceptions` have field msg. E.g.:

```
julia> fieldnames(MethodError)
(:f, :args, :world)
```