### PR TITLE
fix: cannot render html file with <option>

### DIFF
--- a/src/renderers/Html.jl
+++ b/src/renderers/Html.jl
@@ -23,7 +23,7 @@ const HTMLParser = Gumbo
 const MD_SEPARATOR_START = "---\n"
 const MD_SEPARATOR_END   = "---\n"
 
-const NBSP_REPLACEMENT = ("&nbsp;"=>"!!nbsp;;")
+const NBSP_REPLACEMENT = ("&nbsp;" => "!!nbsp;;")
 
 const NORMAL_ELEMENTS = [ :html, :head, :body, :title, :style, :address, :article, :aside, :footer,
                           :header, :h1, :h2, :h3, :h4, :h5, :h6, :hgroup, :nav, :section,
@@ -34,7 +34,7 @@ const NORMAL_ELEMENTS = [ :html, :head, :body, :title, :style, :address, :articl
                           :del, :ins, :caption, :col, :colgroup, :table, :tbody, :td, :tfoot, :th, :thead, :tr,
                           :button, :datalist, :fieldset, :label, :legend, :meter,
                           :output, :progress, :select, :textarea, :details, :dialog, :menu, :menuitem, :summary,
-                          :slot, :template, :blockquote, :center]
+                          :slot, :template, :blockquote, :center, :option]
 const VOID_ELEMENTS   = [:base, :link, :meta, :hr, :br, :area, :img, :track, :param, :source, :input]
 const CUSTOM_ELEMENTS = [:form, :select]
 const BOOL_ATTRIBUTES = [:checked, :disabled, :selected]
@@ -51,43 +51,43 @@ task_local_storage(:__yield, "")
 
 Generates a HTML element in the form <...></...>
 """
-function normal_element(f::Function, elem::String, args = [], attrs::Vector{Pair{Symbol,Any}} = Pair{Symbol,Any}[]) :: HTMLString
-  normal_element(f(), elem, args, attrs...)
+function normal_element(f::Function, elem::String, args = [], attrs::Vector{Pair{Symbol,Any}} = Pair{Symbol,Any}[])::HTMLString
+    normal_element(f(), elem, args, attrs...)
 end
-function normal_element(children::Union{String,Vector{String}}, elem::String, args, attrs::Pair{Symbol,Any}) :: HTMLString
-  normal_element(children, elem, args, Pair{Symbol,Any}[attrs])
+function normal_element(children::Union{String,Vector{String}}, elem::String, args, attrs::Pair{Symbol,Any})::HTMLString
+    normal_element(children, elem, args, Pair{Symbol,Any}[attrs])
 end
-function normal_element(children::Union{String,Vector{String}}, elem::String, args, attrs...) :: HTMLString
-  normal_element(children, elem, args, Pair{Symbol,Any}[attrs...])
+function normal_element(children::Union{String,Vector{String}}, elem::String, args, attrs...)::HTMLString
+    normal_element(children, elem, args, Pair{Symbol,Any}[attrs...])
 end
-function normal_element(children::Union{String,Vector{String}}, elem::String, args = [], attrs::Vector{Pair{Symbol,Any}} = Pair{Symbol,Any}[]) :: HTMLString
-  children = join(children)
-  elem = normalize_element(elem)
-  attribs = rstrip(attributes(attrs))
-  string("<", elem, (isempty(attribs) ? "" : " $attribs"), (isempty(args) ? "" : " $(join(args, " "))"), ">", prepare_template(children), "</", elem, ">")
+function normal_element(children::Union{String,Vector{String}}, elem::String, args = [], attrs::Vector{Pair{Symbol,Any}} = Pair{Symbol,Any}[])::HTMLString
+    children = join(children)
+    elem = normalize_element(elem)
+    attribs = rstrip(attributes(attrs))
+    string("<", elem, (isempty(attribs) ? "" : " $attribs"), (isempty(args) ? "" : " $(join(args, " "))"), ">", prepare_template(children), "</", elem, ">")
 end
-function normal_element(elem::String, attrs::Vector{Pair{Symbol,Any}} = Pair{Symbol,Any}[]) :: HTMLString
-  normal_element("", elem, attrs...)
+function normal_element(elem::String, attrs::Vector{Pair{Symbol,Any}} = Pair{Symbol,Any}[])::HTMLString
+    normal_element("", elem, attrs...)
 end
-function normal_element(elems::Vector, elem::String, args = [], attrs...) :: HTMLString
-  io = IOBuffer()
+function normal_element(elems::Vector, elem::String, args = [], attrs...)::HTMLString
+    io = IOBuffer()
 
-  for e in elems
-    e === nothing && continue
+    for e in elems
+        e === nothing && continue
 
-    if isa(e, Vector)
-      print(io, join(e))
-    elseif isa(e, Function)
-      print(io, e(), "\n")
-    else
-      print(io, e, "\n")
+        if isa(e, Vector)
+            print(io, join(e))
+        elseif isa(e, Function)
+            print(io, e(), "\n")
+        else
+            print(io, e, "\n")
+        end
     end
-  end
 
-  normal_element(String(take!(io)), elem, args, attrs...)
+    normal_element(String(take!(io)), elem, args, attrs...)
 end
-function normal_element(_::Nothing, __::Any) :: HTMLString
-  ""
+function normal_element(_::Nothing, __::Any)::HTMLString
+    ""
 end
 
 
@@ -97,15 +97,15 @@ end
 
 Cleans up the template before rendering (ex by removing empty nodes).
 """
-function prepare_template(s::String) :: String
-  s
+function prepare_template(s::String)::String
+    s
 end
 function prepare_template(v::Vector{T})::String where {T}
-  filter!(v) do (x)
-    ! isa(x, Nothing)
-  end
+    filter!(v) do (x)
+        ! isa(x, Nothing)
+    end
 
-  join(v)
+    join(v)
 end
 
 
@@ -114,14 +114,14 @@ end
 
 Parses HTML attributes.
 """
-function attributes(attrs::Vector{Pair{Symbol,Any}} = Vector{Pair{Symbol,Any}}()) :: String
-  a = IOBuffer()
+function attributes(attrs::Vector{Pair{Symbol,Any}} = Vector{Pair{Symbol,Any}}())::String
+    a = IOBuffer()
 
-  for (k,v) in attrs
-    print(a, "$(k)=\"$(v)\" ")
-  end
+    for (k, v) in attrs
+        print(a, "$(k)=\"$(v)\" ")
+    end
 
-  String(take!(a))
+    String(take!(a))
 end
 
 
@@ -131,10 +131,10 @@ end
 Cleans up problematic characters or DOM elements.
 """
 function normalize_element(elem::String)
-  replace(string(lowercase(elem)), "_____"=>"-")
+    replace(string(lowercase(elem)), "_____" => "-")
 end
 function denormalize_element(elem::String)
-  replace(string(lowercase(elem)), "-"=>"_____")
+    replace(string(lowercase(elem)), "-" => "_____")
 end
 
 
@@ -143,9 +143,9 @@ end
 
 Generates a void HTML element in the form <...>
 """
-function void_element(elem::String, args = [], attrs::Vector{Pair{Symbol,Any}} = Pair{Symbol,Any}[]) :: HTMLString
-  attribs = rstrip(attributes(attrs))
-  string("<", normalize_element(elem), (isempty(attribs) ? "" : " $attribs"), (isempty(args) ? "" : " $(join(args, " "))"), ">")
+function void_element(elem::String, args = [], attrs::Vector{Pair{Symbol,Any}} = Pair{Symbol,Any}[])::HTMLString
+    attribs = rstrip(attributes(attrs))
+    string("<", normalize_element(elem), (isempty(attribs) ? "" : " $attribs"), (isempty(args) ? "" : " $(join(args, " "))"), ">")
 end
 
 
@@ -155,11 +155,11 @@ end
 
 Cleans up empty elements.
 """
-function skip_element(f::Function) :: HTMLString
-  "$(prepare_template(f()))"
+function skip_element(f::Function)::HTMLString
+    "$(prepare_template(f()))"
 end
-function skip_element() :: HTMLString
-  ""
+function skip_element()::HTMLString
+    ""
 end
 
 
@@ -169,22 +169,22 @@ end
 Includes and renders a markdown view file
 """
 function include_markdown(path::String; context::Module = @__MODULE__)
-  md = read(path, String)
+    md = read(path, String)
 
-  if startswith(md, MD_SEPARATOR_START)
-    close_sep_pos = findfirst(MD_SEPARATOR_END, md[length(MD_SEPARATOR_START)+1:end])
-    metadata = md[length(MD_SEPARATOR_START)+1:close_sep_pos[end]] |> YAML.load
+    if startswith(md, MD_SEPARATOR_START)
+        close_sep_pos = findfirst(MD_SEPARATOR_END, md[length(MD_SEPARATOR_START) + 1:end])
+        metadata = md[length(MD_SEPARATOR_START) + 1:close_sep_pos[end]] |> YAML.load
 
-    for (k,v) in metadata
-      task_local_storage(:__vars)[Symbol(k)] = v
+        for (k, v) in metadata
+            task_local_storage(:__vars)[Symbol(k)] = v
+        end
+
+        md = replace(md[close_sep_pos[end] + length(MD_SEPARATOR_END) + 1:end], "\"\"\"" => "\\\"\\\"\\\"")
     end
 
-    md = replace(md[close_sep_pos[end]+length(MD_SEPARATOR_END)+1:end], "\"\"\""=>"\\\"\\\"\\\"")
-  end
+    content = string("\"\"\"", md, "\"\"\"")
 
-  content = string( "\"\"\"", md, "\"\"\"")
-
-  "", (Base.include_string(context, content) |> Markdown.parse |> Markdown.html)
+    "", (Base.include_string(context, content) |> Markdown.parse |> Markdown.html)
 end
 
 
@@ -193,53 +193,53 @@ end
 
 Resolves the inclusion and rendering of a template file
 """
-function get_template(path::String; partial::Bool = true, context::Module = @__MODULE__) :: Function
-  orig_path = path
+function get_template(path::String; partial::Bool = true, context::Module = @__MODULE__)::Function
+    orig_path = path
 
-  path, extension = Genie.Renderer.view_file_info(path, SUPPORTED_HTML_OUTPUT_FILE_FORMATS)
+    path, extension = Genie.Renderer.view_file_info(path, SUPPORTED_HTML_OUTPUT_FILE_FORMATS)
 
-  isfile(path) || error("Template file \"$orig_path\" with extensions $SUPPORTED_HTML_OUTPUT_FILE_FORMATS does not exist")
+    isfile(path) || error("Template file \"$orig_path\" with extensions $SUPPORTED_HTML_OUTPUT_FILE_FORMATS does not exist")
 
-  extension in HTML_FILE_EXT && return (() -> Base.include(context, path))
+    extension in HTML_FILE_EXT && return (()->Base.include(context, path))
 
-  f_name = Genie.Renderer.function_name(string(path, partial)) |> Symbol
-  mod_name = Genie.Renderer.m_name(string(path, partial)) * ".jl"
-  f_path = joinpath(Genie.config.path_build, Genie.Renderer.BUILD_NAME, mod_name)
-  f_stale = Genie.Renderer.build_is_stale(path, f_path)
+    f_name = Genie.Renderer.function_name(string(path, partial)) |> Symbol
+    mod_name = Genie.Renderer.m_name(string(path, partial)) * ".jl"
+    f_path = joinpath(Genie.config.path_build, Genie.Renderer.BUILD_NAME, mod_name)
+    f_stale = Genie.Renderer.build_is_stale(path, f_path)
 
-  if f_stale || ! isdefined(context, f_name)
-    content = if extension in MARKDOWN_FILE_EXT
-      vars_injection, md = include_markdown(path, context = context)
-      string_to_julia(md, partial = partial, f_name = f_name, prepend = vars_injection)
-    else
-      html_to_julia(path, partial = partial)
+    if f_stale || ! isdefined(context, f_name)
+        content = if extension in MARKDOWN_FILE_EXT
+            vars_injection, md = include_markdown(path, context = context)
+            string_to_julia(md, partial = partial, f_name = f_name, prepend = vars_injection)
+        else
+            html_to_julia(path, partial = partial)
+        end
+
+        f_stale && Genie.Renderer.build_module(content, path, mod_name)
+
+        return Base.include(context, joinpath(Genie.config.path_build, Genie.Renderer.BUILD_NAME, mod_name))
     end
 
-    f_stale && Genie.Renderer.build_module(content, path, mod_name)
-
-    return Base.include(context, joinpath(Genie.config.path_build, Genie.Renderer.BUILD_NAME, mod_name))
-  end
-
-  getfield(context, f_name)
+    getfield(context, f_name)
 end
 
 
 """
 Outputs document's doctype.
 """
-function doctype(doctype::Symbol = :html) :: HTMLString
-  "<!DOCTYPE $doctype>"
+function doctype(doctype::Symbol = :html)::HTMLString
+    "<!DOCTYPE $doctype>"
 end
 
 
 """
 Outputs document's doctype.
 """
-function doc(html::String) :: HTMLString
-  doctype() * "\n" * html
+function doc(html::String)::HTMLString
+    doctype() * "\n" * html
 end
-function doc(doctype::Symbol, html::String) :: HTMLString
-  doctype(doctype) * "\n" * html
+function doc(doctype::Symbol, html::String)::HTMLString
+    doctype(doctype) * "\n" * html
 end
 
 
@@ -248,83 +248,83 @@ end
 
 Parses a view file, returning a rendering function. If necessary, the function is JIT-compiled, persisted and loaded into memory.
 """
-function parseview(data::String; partial = false, context::Module = @__MODULE__) :: Function
-  data_hash = hash(data)
-  path = "Genie_" * string(data_hash)
+function parseview(data::String; partial = false, context::Module = @__MODULE__)::Function
+    data_hash = hash(data)
+    path = "Genie_" * string(data_hash)
 
-  func_name = Genie.Renderer.function_name(string(data_hash, partial)) |> Symbol
-  mod_name = Genie.Renderer.m_name(string(path, partial)) * ".jl"
-  f_path = joinpath(Genie.config.path_build, Genie.Renderer.BUILD_NAME, mod_name)
-  f_stale = Genie.Renderer.build_is_stale(f_path, f_path)
+    func_name = Genie.Renderer.function_name(string(data_hash, partial)) |> Symbol
+    mod_name = Genie.Renderer.m_name(string(path, partial)) * ".jl"
+    f_path = joinpath(Genie.config.path_build, Genie.Renderer.BUILD_NAME, mod_name)
+    f_stale = Genie.Renderer.build_is_stale(f_path, f_path)
 
-  if f_stale || ! isdefined(context, func_name)
-    f_stale && Genie.Renderer.build_module(string_to_julia(data, partial = partial), path, mod_name)
+    if f_stale || ! isdefined(context, func_name)
+        f_stale && Genie.Renderer.build_module(string_to_julia(data, partial = partial), path, mod_name)
 
-    return Base.include(context, joinpath(Genie.config.path_build, Genie.Renderer.BUILD_NAME, mod_name))
-  end
+        return Base.include(context, joinpath(Genie.config.path_build, Genie.Renderer.BUILD_NAME, mod_name))
+    end
 
-  getfield(context, func_name)
+    getfield(context, func_name)
 end
 
 
 """
 """
-function render(data::String; context::Module = @__MODULE__, layout::Union{String,Nothing} = nothing, vars...) :: Function
-  Genie.Renderer.registervars(vars...)
+function render(data::String; context::Module = @__MODULE__, layout::Union{String,Nothing} = nothing, vars...)::Function
+    Genie.Renderer.registervars(vars...)
 
-  if layout !== nothing
-    task_local_storage(:__yield, parseview(data, partial = true, context = context))
-    parseview(layout, partial = false, context = context)
-  else
-    parseview(data, partial = false, context = context)
-  end
+    if layout !== nothing
+        task_local_storage(:__yield, parseview(data, partial = true, context = context))
+        parseview(layout, partial = false, context = context)
+    else
+        parseview(data, partial = false, context = context)
+    end
 end
 
 
 """
 """
-function render(viewfile::Genie.Renderer.FilePath; layout::Union{Nothing,Genie.Renderer.FilePath} = nothing, context::Module = @__MODULE__, vars...) :: Function
-  Genie.Renderer.registervars(vars...)
+function render(viewfile::Genie.Renderer.FilePath; layout::Union{Nothing,Genie.Renderer.FilePath} = nothing, context::Module = @__MODULE__, vars...)::Function
+    Genie.Renderer.registervars(vars...)
 
-  if layout !== nothing
-    task_local_storage(:__yield, get_template(string(viewfile), partial = true, context = context))
-    get_template(string(layout), partial = false, context = context)
-  else
-    get_template(string(viewfile), partial = false, context = context)
-  end
+    if layout !== nothing
+        task_local_storage(:__yield, get_template(string(viewfile), partial = true, context = context))
+        get_template(string(layout), partial = false, context = context)
+    else
+        get_template(string(viewfile), partial = false, context = context)
+    end
 end
 
 
-function parsehtml(input::String; partial::Bool = true) :: String
-  parsehtml(HTMLParser.parsehtml(replace(input, NBSP_REPLACEMENT)).root, 0, partial = partial)
+function parsehtml(input::String; partial::Bool = true)::String
+    parsehtml(HTMLParser.parsehtml(replace(input, NBSP_REPLACEMENT)).root, 0, partial = partial)
 end
 
 
-function Genie.Renderer.render(::Type{MIME"text/html"}, data::String; context::Module = @__MODULE__, layout::Union{String,Nothing} = nothing, vars...) :: Genie.Renderer.WebRenderable
-  try
-    render(data; context = context, layout = layout, vars...) |> Genie.Renderer.WebRenderable
-  catch ex
-    isa(ex, KeyError) && Genie.Renderer.changebuilds() # it's a view error so don't reuse them
-    rethrow(ex)
-  end
+function Genie.Renderer.render(::Type{MIME"text/html"}, data::String; context::Module = @__MODULE__, layout::Union{String,Nothing} = nothing, vars...)::Genie.Renderer.WebRenderable
+    try
+        render(data; context = context, layout = layout, vars...) |> Genie.Renderer.WebRenderable
+    catch ex
+        isa(ex, KeyError) && Genie.Renderer.changebuilds() # it's a view error so don't reuse them
+        rethrow(ex)
+    end
 end
 
 
-function Genie.Renderer.render(::Type{MIME"text/html"}, viewfile::Genie.Renderer.FilePath; layout::Union{Nothing,Genie.Renderer.FilePath} = nothing, context::Module = @__MODULE__, vars...) :: Genie.Renderer.WebRenderable
-  try
-    render(viewfile; layout = layout, context = context, vars...) |> Genie.Renderer.WebRenderable
-  catch ex
-    isa(ex, KeyError) && Genie.Renderer.changebuilds() # it's a view error so don't reuse them
-    rethrow(ex)
-  end
+function Genie.Renderer.render(::Type{MIME"text/html"}, viewfile::Genie.Renderer.FilePath; layout::Union{Nothing,Genie.Renderer.FilePath} = nothing, context::Module = @__MODULE__, vars...)::Genie.Renderer.WebRenderable
+    try
+        render(viewfile; layout = layout, context = context, vars...) |> Genie.Renderer.WebRenderable
+    catch ex
+        isa(ex, KeyError) && Genie.Renderer.changebuilds() # it's a view error so don't reuse them
+        rethrow(ex)
+    end
 end
 
 
 """
 """
 function html(resource::Genie.Renderer.ResourcePath, action::Genie.Renderer.ResourcePath; layout::Genie.Renderer.ResourcePath = DEFAULT_LAYOUT_FILE,
-                context::Module = @__MODULE__, status::Int = 200, headers::Genie.Renderer.HTTPHeaders = Genie.Renderer.HTTPHeaders(), vars...) :: Genie.Renderer.HTTP.Response
-  html(Genie.Renderer.Path(joinpath(Genie.config.path_resources, string(resource), Renderer.VIEWS_FOLDER, string(action)));
+                context::Module = @__MODULE__, status::Int = 200, headers::Genie.Renderer.HTTPHeaders = Genie.Renderer.HTTPHeaders(), vars...)::Genie.Renderer.HTTP.Response
+    html(Genie.Renderer.Path(joinpath(Genie.config.path_resources, string(resource), Renderer.VIEWS_FOLDER, string(action)));
         layout = Genie.Renderer.Path(joinpath(Genie.config.path_app, LAYOUTS_FOLDER, string(layout))),
         context = context, status = status, headers = headers, vars...)
 end
@@ -354,7 +354,7 @@ Content-Type: text/html; charset=utf-8
 </div></body></html>"
 ```
 """
-function html(data::String; context::Module = @__MODULE__, status::Int = 200, headers::Genie.Renderer.HTTPHeaders = Genie.Renderer.HTTPHeaders(), layout::Union{String,Nothing} = nothing, forceparse::Bool = false, vars...) :: Genie.Renderer.HTTP.Response
+function html(data::String; context::Module = @__MODULE__, status::Int = 200, headers::Genie.Renderer.HTTPHeaders = Genie.Renderer.HTTPHeaders(), layout::Union{String,Nothing} = nothing, forceparse::Bool = false, vars...)::Genie.Renderer.HTTP.Response
   if occursin(raw"$", data) || occursin("<%", data) || layout !== nothing || forceparse
     Genie.Renderer.WebRenderable(Genie.Renderer.render(MIME"text/html", data; context = context, layout = layout, vars...), status, headers) |> Genie.Renderer.respond
   else
@@ -377,7 +377,7 @@ Parses and renders the HTML `viewfile`, optionally rendering it within the `layo
 - `headers::HTTPHeaders`: HTTP response headers
 """
 function html(viewfile::Genie.Renderer.FilePath; layout::Union{Nothing,Genie.Renderer.FilePath} = nothing,
-                context::Module = @__MODULE__, status::Int = 200, headers::Genie.Renderer.HTTPHeaders = Genie.Renderer.HTTPHeaders(), vars...) :: Genie.Renderer.HTTP.Response
+                context::Module = @__MODULE__, status::Int = 200, headers::Genie.Renderer.HTTPHeaders = Genie.Renderer.HTTPHeaders(), vars...)::Genie.Renderer.HTTP.Response
   Genie.Renderer.WebRenderable(Genie.Renderer.render(MIME"text/html", viewfile; layout = layout, context = context, vars...), status, headers) |> Genie.Renderer.respond
 end
 
@@ -387,7 +387,7 @@ end
 
 Parses a HTML tree structure into a `string` of Julia code.
 """
-function parsehtml(elem::HTMLParser.HTMLElement, depth::Int = 0; partial::Bool = true) :: String
+function parsehtml(elem::HTMLParser.HTMLElement, depth::Int = 0; partial::Bool = true)::String
   io = IOBuffer()
 
   tag_name = denormalize_element(string(HTMLParser.tag(elem)))
@@ -406,7 +406,7 @@ function parsehtml(elem::HTMLParser.HTMLElement, depth::Int = 0; partial::Bool =
     attributes_keys = String[]
     attributes_values = String[]
 
-    for (k,v) in HTMLParser.attrs(elem)
+    for (k, v) in HTMLParser.attrs(elem)
       x = v
       k = string(k) |> lowercase
 
@@ -424,7 +424,7 @@ function parsehtml(elem::HTMLParser.HTMLElement, depth::Int = 0; partial::Bool =
           push!(attributes_keys, Symbol(k) |> repr)
 
           v = string(v) |> repr
-          occursin(raw"\$", v) && (v = replace(v, raw"\$"=>raw"$"))
+          occursin(raw"\$", v) && (v = replace(v, raw"\$" => raw"$"))
           push!(attributes_values, v)
         else
           print(attributes, """$k="$v" """, ", ")
@@ -433,7 +433,7 @@ function parsehtml(elem::HTMLParser.HTMLElement, depth::Int = 0; partial::Bool =
     end
 
     attributes_string = String(take!(attributes))
-    endswith(attributes_string, ", ") && (attributes_string = attributes_string[1:end-2])
+    endswith(attributes_string, ", ") && (attributes_string = attributes_string[1:end - 2])
 
     print(io, attributes_string)
     ! isempty(attributes_string) && ! isempty(attributes_keys) && print(io, ", ")
@@ -453,7 +453,7 @@ function parsehtml(elem::HTMLParser.HTMLElement, depth::Int = 0; partial::Bool =
         idx += 1
         inner *= isa(child, HTMLParser.HTMLText) ? parsehtml(child, depth + 1) : parsehtml(child, depth + 1, partial = partial)
         if idx < children_count
-          if  ( isa(child, HTMLParser.HTMLText) ) ||
+          if ( isa(child, HTMLParser.HTMLText) ) ||
               ( isa(child, HTMLParser.HTMLElement) &&
               ( ! in("type", collect(keys(HTMLParser.attrs(child)))) ||
                 ( in("type", collect(keys(HTMLParser.attrs(child)))) && (HTMLParser.attrs(child)["type"] != "julia/eval") ) ) )
@@ -463,7 +463,7 @@ function parsehtml(elem::HTMLParser.HTMLElement, depth::Int = 0; partial::Bool =
       end
 
       if ! isempty(inner)
-        endswith(inner, "\n\n") && (inner = inner[1:end-2])
+        endswith(inner, "\n\n") && (inner = inner[1:end - 2])
         print(io, inner, repeat("\t", depth))
       end
 
@@ -476,10 +476,10 @@ function parsehtml(elem::HTMLParser.HTMLElement, depth::Int = 0; partial::Bool =
 end
 
 
-function parsehtml(elem::HTMLParser.HTMLText, depth::Int = 0; partial::Bool = true) :: String
+function parsehtml(elem::HTMLParser.HTMLText, depth::Int = 0; partial::Bool = true)::String
   content = elem.text
   endswith(content, "\"") && (content *= Char(0x0))
-  content = replace(content, NBSP_REPLACEMENT[2]=>NBSP_REPLACEMENT[1])
+  content = replace(content, NBSP_REPLACEMENT[2] => NBSP_REPLACEMENT[1])
   string(repeat("\t", depth), "\"\"\"$(content)\"\"\"")
 end
 
@@ -489,7 +489,7 @@ end
 
 Converts a HTML document to Julia code.
 """
-function html_to_julia(file_path::String; partial = true) :: String
+function html_to_julia(file_path::String; partial = true)::String
   to_julia(file_path, parse_template, partial = partial)
 end
 
@@ -499,7 +499,7 @@ end
 
 Converts string view data to Julia code
 """
-function string_to_julia(content::String; partial = true, f_name::Union{Symbol,Nothing} = nothing, prepend = "") :: String
+function string_to_julia(content::String; partial = true, f_name::Union{Symbol,Nothing} = nothing, prepend = "")::String
   to_julia(content, parse_string, partial = partial, f_name = f_name, prepend = prepend)
 end
 
@@ -509,7 +509,7 @@ end
 
 Converts an input file to Julia code
 """
-function to_julia(input::String, f::Function; partial = true, f_name::Union{Symbol,Nothing} = nothing, prepend = "\n") :: String
+function to_julia(input::String, f::Function; partial = true, f_name::Union{Symbol,Nothing} = nothing, prepend = "\n")::String
   f_name = (f_name === nothing) ? Genie.Renderer.function_name(string(input, partial)) : f_name
 
   string("function $(f_name)() \n",
@@ -525,8 +525,8 @@ end
 
 Renders (includes) a view partial within a larger view or layout file.
 """
-function partial(path::String; context::Module = @__MODULE__, vars...) :: String
-  for (k,v) in vars
+function partial(path::String; context::Module = @__MODULE__, vars...)::String
+  for (k, v) in vars
     try
       task_local_storage(:__vars)[k] = v
     catch
@@ -544,7 +544,7 @@ end
 
 Renders a template file.
 """
-function template(path::String; partial::Bool = true, context::Module = @__MODULE__) :: String
+function template(path::String; partial::Bool = true, context::Module = @__MODULE__)::String
   try
     get_template(path, partial = partial, context = context)()
   catch
@@ -558,7 +558,7 @@ end
 
 Reads `file_path` template from disk.
 """
-function read_template_file(file_path::String) :: String
+function read_template_file(file_path::String)::String
   io = IOBuffer()
   open(file_path) do f
     for line in enumerate(eachline(f))
@@ -575,7 +575,7 @@ end
 
 Parses a HTML file into Julia code.
 """
-function parse_template(file_path::String; partial::Bool = true) :: String
+function parse_template(file_path::String; partial::Bool = true)::String
   parse(read_template_file(file_path), partial = partial)
 end
 
@@ -585,12 +585,12 @@ end
 
 Parses a HTML string into Julia code.
 """
-function parse_string(data::String; partial::Bool = true) :: String
+function parse_string(data::String; partial::Bool = true)::String
   parse(parsetags(data), partial = partial)
 end
 
 
-function parse(input::String; partial::Bool = true) :: String
+function parse(input::String; partial::Bool = true)::String
   parsehtml(input, partial = partial)
 end
 
@@ -600,15 +600,15 @@ end
 
 Parses special HTML+Julia tags.
 """
-function parsetags(line::Tuple{Int,String}) :: String
+function parsetags(line::Tuple{Int,String})::String
   parsetags(line[2])
 end
 
 
-function parsetags(code::String) :: String
+function parsetags(code::String)::String
   replace(
-    replace(code, "<%"=>"""<script type="julia/eval">"""),
-    "%>"=>"""</script>""")
+    replace(code, "<%" => """<script type="julia/eval">"""),
+    "%>" => """</script>""")
 end
 
 
@@ -617,7 +617,7 @@ end
 
 Generated functions that represent Julia functions definitions corresponding to HTML elements.
 """
-function register_elements() :: Nothing
+function register_elements()::Nothing
   for elem in NORMAL_ELEMENTS
     register_normal_element(elem)
   end
@@ -634,7 +634,7 @@ function register_elements() :: Nothing
 end
 
 
-function register_element(elem::Union{Symbol,String}, elem_type::Union{Symbol,String} = :normal; context = @__MODULE__) :: Nothing
+function register_element(elem::Union{Symbol,String}, elem_type::Union{Symbol,String} = :normal; context = @__MODULE__)::Nothing
   elem = string(elem)
   occursin('-', elem) && (elem = denormalize_element(elem))
 
@@ -642,7 +642,7 @@ function register_element(elem::Union{Symbol,String}, elem_type::Union{Symbol,St
 end
 
 
-function register_normal_element(elem::Union{Symbol,String}; context = @__MODULE__) :: Nothing
+function register_normal_element(elem::Union{Symbol,String}; context = @__MODULE__)::Nothing
   Core.eval(context, """
     function $elem(f::Function, args...; attrs...) :: HTMLString
       \"\"\"\$(normal_element(f, "$(string(elem))", [args...], Pair{Symbol,Any}[attrs...]))\"\"\"
@@ -659,7 +659,7 @@ function register_normal_element(elem::Union{Symbol,String}; context = @__MODULE
 end
 
 
-function register_void_element(elem::Union{Symbol,String}; context = @__MODULE__) :: Nothing
+function register_void_element(elem::Union{Symbol,String}; context = @__MODULE__)::Nothing
   Core.eval(context, """
     function $elem(args...; attrs...) :: HTMLString
       \"\"\"\$(void_element("$(string(elem))", [args...], Pair{Symbol,Any}[attrs...]))\"\"\"
@@ -701,17 +701,17 @@ end
 ### EXCEPTIONS ###
 
 
-function Genie.Router.error(error_message::String, ::Type{MIME"text/html"}, ::Val{500}; error_info::String = "") :: HTTP.Response
+function Genie.Router.error(error_message::String, ::Type{MIME"text/html"}, ::Val{500}; error_info::String = "")::HTTP.Response
   serve_error_file(500, error_message, error_info = error_info)
 end
 
 
-function Genie.Router.error(error_message::String, ::Type{MIME"text/html"}, ::Val{404}; error_info::String = "") :: HTTP.Response
+function Genie.Router.error(error_message::String, ::Type{MIME"text/html"}, ::Val{404}; error_info::String = "")::HTTP.Response
   serve_error_file(404, error_message, error_info = error_info)
 end
 
 
-function Genie.Router.error(error_code::Int, error_message::String, ::Type{MIME"text/html"}; error_info::String = "") :: HTTP.Response
+function Genie.Router.error(error_code::Int, error_message::String, ::Type{MIME"text/html"}; error_info::String = "")::HTTP.Response
   serve_error_file(error_code, error_message, error_info = error_info)
 end
 
@@ -721,7 +721,7 @@ end
 
 Serves the error file correspoding to `error_code` and current environment.
 """
-function serve_error_file(error_code::Int, error_message::String = ""; error_info::String = "") :: HTTP.Response
+function serve_error_file(error_code::Int, error_message::String = ""; error_info::String = "")::HTTP.Response
   page_code = error_code in [404, 500] ? "$error_code" : "xxx"
 
   try
@@ -734,30 +734,30 @@ function serve_error_file(error_code::Int, error_message::String = ""; error_inf
                   end
 
     if error_code == 500
-      error_page = replace(error_page, "<error_description/>"=>split(error_message, "\n")[1])
+      error_page = replace(error_page, "<error_description/>" => split(error_message, "\n")[1])
 
       error_message = if Genie.Configuration.isdev()
-                      """$("#" ^ 25) ERROR STACKTRACE $("#" ^ 25)\n$error_message                                     $("\n" ^ 3)""" *
-                      """$("#" ^ 25)  REQUEST PARAMS  $("#" ^ 25)\n$(Millboard.table(Genie.Router.@params))                        $("\n" ^ 3)""" *
-                      """$("#" ^ 25)     ROUTES       $("#" ^ 25)\n$(Millboard.table(Genie.Router.named_routes() |> Dict))  $("\n" ^ 3)""" *
-                      """$("#" ^ 25)    JULIA ENV     $("#" ^ 25)\n$ENV                                               $("\n" ^ 1)"""
+                      """$("#"^25) ERROR STACKTRACE $("#"^25)\n$error_message                                     $("\n"^3)""" *
+                      """$("#"^25)  REQUEST PARAMS  $("#"^25)\n$(Millboard.table(Genie.Router.@params))                        $("\n"^3)""" *
+                      """$("#"^25)     ROUTES       $("#"^25)\n$(Millboard.table(Genie.Router.named_routes() |> Dict))  $("\n"^3)""" *
+                      """$("#"^25)    JULIA ENV     $("#"^25)\n$ENV                                               $("\n"^1)"""
       else
         ""
       end
 
-      error_page = replace(error_page, "<error_message/>"=>escapeHTML(error_message))
+      error_page = replace(error_page, "<error_message/>" => escapeHTML(error_message))
 
     elseif error_code == 404
-      error_page = replace(error_page, "<error_message/>"=>error_message)
+      error_page = replace(error_page, "<error_message/>" => error_message)
 
     else
-      error_page = replace(replace(error_page, "<error_message/>"=>error_message), "<error_info/>"=>error_info)
+      error_page = replace(replace(error_page, "<error_message/>" => error_message), "<error_info/>" => error_info)
     end
 
-    HTTP.Response(error_code, ["Content-Type"=>"text/html"], body = error_page)
+    HTTP.Response(error_code, ["Content-Type" => "text/html"], body = error_page)
   catch ex
     @error ex
-    HTTP.Response(error_code, ["Content-Type"=>"text/html"], body = "Error $page_code: $error_message")
+    HTTP.Response(error_code, ["Content-Type" => "text/html"], body = "Error $page_code: $error_message")
   end
 end
 

--- a/src/renderers/html/select.jl
+++ b/src/renderers/html/select.jl
@@ -1,39 +1,39 @@
-Base.@kwdef struct option
-  disabled::Bool = false
-  selected::Bool = false
-  value::String = ""
-  text::String = value
+Base.@kwdef struct Option
+    disabled::Bool = false
+    selected::Bool = false
+    value::String = ""
+    text::String = value
 end
 
 
-function Base.string(o::option) :: HTMLString
-  attributes = String[]
+function Base.string(o::Option)::HTMLString
+    attributes = String[]
 
-  o.disabled && push!(attributes, "disabled")
-  o.selected && push!(attributes, "selected")
-  push!(attributes, "value=\"$(o.value)\"")
+    o.disabled && push!(attributes, "disabled")
+    o.selected && push!(attributes, "selected")
+    push!(attributes, "value=\"$(o.value)\"")
 
-  "<option $(join(attributes, " "))>$(o.text)</option>"
+    "<option $(join(attributes, " "))>$(o.text)</option>"
 end
 
 
-function select(options::Vector{option}, args...; attrs...) :: HTMLString
-  children = String[]
+function select(options::Vector{Option}, args...; attrs...)::HTMLString
+    children = String[]
 
-  for o in options
-    push!(children, string(o))
-  end
+    for o in options
+        push!(children, string(o))
+    end
 
-  normal_element(children, "select", [args...], Pair{Symbol,Any}[attrs...])
+    normal_element(children, "select", [args...], Pair{Symbol,Any}[attrs...])
 end
 
 
-function optgroup(options::Vector{option}, args...; attrs...) :: HTMLString
-  children = String[]
+function optgroup(options::Vector{Option}, args...; attrs...)::HTMLString
+    children = String[]
 
-  for o in options
-    push!(children, string(o))
-  end
+    for o in options
+        push!(children, string(o))
+    end
 
-  normal_element(children, "optgroup", [args...], Pair{Symbol,Any}[attrs...])
+    normal_element(children, "optgroup", [args...], Pair{Symbol,Any}[attrs...])
 end


### PR DESCRIPTION
I used Genie v0.27.0 and found Genie cannot render the following JL HTML (app/resources/xx/views/xx.jl.html):

```html
<form action="/new" method="POST" enctype="multipart/form-data">
  <div class="form-group">
    <label for="exampleFormControlSelect1">Example select</label>
    <select class="form-control" id="exampleFormControlSelect1">
      <option>1</option>
      <option>2</option>
      <option>3</option>
      <option>4</option>
      <option>5</option>
    </select>
  </div>
  <button type="submit" class="btn btn-primary">Submit</button>
</form>
````

And the error messages:
```
┌ Error: 2020-03-10 14:58:29 MethodError(Genie.Renderer.Html.option, (Genie.Renderer.Html.var"#366#403"(),), 0x000000000000694a)
└ @ Genie.AppServer ~/.julia/packages/Genie/xh3hJ/src/AppServer.jl:103
┌ Error: 2020-03-10 14:58:30 MethodError: no method matching Genie.Renderer.Html.option(::Genie.Renderer.Html.var"#366#403")
│ Closest candidates are:
│   Genie.Renderer.Html.option(::Any, !Matched::Any, !Matched::Any, !Matched::Any) at /home/jiacheng/.julia/packages/Genie/xh3hJ/src/renderers/html/select.jl:2
│   Genie.Renderer.Html.option(; disabled, selected, value, text) at util.jl:722
│   Genie.Renderer.Html.option(!Matched::Bool, !Matched::Bool, !Matched::String, !Matched::String) at /home/jiacheng/.julia/packages/Genie/xh3hJ/src/renderers/html/select.jl:2
│ (::Genie.Renderer.Html.var"#365#402")() at /tmp/jl_genie_build_aTCrHQ/GenieViews/1cac87da8c3b1670daed600394ff306da6a4b0fc.jl:30
...
```

It was because `option` was declared as a type in `select.jl` , rather than a function.

My changes are as follows:
- Keeping the implements of `select.jl`, but changing the type `option` to `Option`. (select.jl)
- Pushing `:option` to the end of `const NORMAL_ELEMENTS`.