### PR TITLE
Evaluate const secret_token in the provided context

### DIFF
--- a/src/genie_module.jl
+++ b/src/genie_module.jl
@@ -218,8 +218,12 @@ function secret_token(; context::Union{Module,Nothing} = nothing) :: String
           or use the included /app/config/secrets.jl.example file as a model."
 
     st = Generator.secret_token()
-    Core.eval(@__MODULE__, Meta.parse("""const SECRET_TOKEN = "$st" """))
-
+    if typeof(context) <: Nothing
+        Core.eval(@__MODULE__, Meta.parse("""const SECRET_TOKEN = "$st" """))
+    else
+        Core.eval(context, Meta.parse("""const SECRET_TOKEN = "$st" """))
+    end
+    
     st
   end
 end


### PR DESCRIPTION
This solves a fairly corner-case bug. To reproduce:

1. Create a new Genie app with `Genie.newapp`
2. Delete the secrets file
3. Start the app (in dev mode; not sure this matters).

Fails due to:
```
ERROR: LoadError: LoadError: LoadError: LoadError: cannot declare SECRET_TOKEN constant; it already has a value
```

I _think_ I have fixed this by `eval`ing `SECRET_TOKEN` in the `context` provided to load (if one is provided), rather than `eval`ing in the `@__MODULE__`.