### PR TITLE
Fix the path string to Julia for win env. setups

### DIFF
--- a/src/Generator.jl
+++ b/src/Generator.jl
@@ -126,19 +126,19 @@ Creates the bin/server and bin/repl binaries for Windows
 """
 function setup_windows_bin_files(path::String = ".") :: Nothing
   open(joinpath(path, Genie.config.path_bin, "repl.bat"), "w") do f
-    write(f, "$JULIA_PATH --color=yes --depwarn=no -q -i -- ../$(Genie.BOOTSTRAP_FILE_NAME) %*")
+    write(f, "\"$JULIA_PATH\" --color=yes --depwarn=no -q -i -- ../$(Genie.BOOTSTRAP_FILE_NAME) %*")
   end
 
   open(joinpath(path, Genie.config.path_bin, "server.bat"), "w") do f
-    write(f, "$JULIA_PATH --color=yes --depwarn=no -q -i -- ../$(Genie.BOOTSTRAP_FILE_NAME) s %*")
+    write(f, "\"$JULIA_PATH\" --color=yes --depwarn=no -q -i -- ../$(Genie.BOOTSTRAP_FILE_NAME) s %*")
   end
 
   open(joinpath(path, Genie.config.path_bin, "serverinteractive.bat"), "w") do f
-    write(f, "$JULIA_PATH --color=yes --depwarn=no -q -i -- ../$(Genie.BOOTSTRAP_FILE_NAME) si %*")
+    write(f, "\"$JULIA_PATH\" --color=yes --depwarn=no -q -i -- ../$(Genie.BOOTSTRAP_FILE_NAME) si %*")
   end
 
   open(joinpath(path, Genie.config.path_bin, "runtask.bat"), "w") do f
-    write(f, "$JULIA_PATH --color=yes --depwarn=no -q -- ../$(Genie.BOOTSTRAP_FILE_NAME) -r %*")
+    write(f, "\"$JULIA_PATH\" --color=yes --depwarn=no -q -- ../$(Genie.BOOTSTRAP_FILE_NAME) -r %*")
   end
 
   nothing


### PR DESCRIPTION
In Windows env, the path to Julia.exe sometimes contains white spaces. In my case, the path is like this: `C:\Users\o028574\AppData\Local\Programs\Julia 1.5.0\bin\julia`. In this case, bat files in `bin` does not work correctly.

A following example is the case where I created MyGenie folder with `Genie.newapp("MyGenie")` command.
```
D:\workspace\MyGenie>bin\repl.bat

D:\workspace\MyGenie>C:\Users\o028574\AppData\Local\Programs\Julia 1.5.0\bin\julia --color=yes --depwarn=no -q -i -- ../bootstrap.jl
'C:\Users\o028574\AppData\Local\Programs\Julia' is not recognized as an internal or external command, operable program or batch file.
```

To avoid the white space issue, it might be needed to surround the path string with double quotations.

```
"C:\Users\o028574\AppData\Local\Programs\Julia 1.5.0\bin\julia" --color=yes --depwarn=no -q -i -- ../bootstrap.jl %*
```