### PR TITLE
change clientside calculation of ws connection

### DIFF
--- a/files/embedded/channels.js
+++ b/files/embedded/channels.js
@@ -1,6 +1,6 @@
 Genie.WebChannels = {};
 Genie.WebChannels.load_channels = function() {
-  var socket = new WebSocket('ws://' + window.Genie.Settings.server_host + ':' + window.Genie.Settings.websockets_port);
+  var socket = new WebSocket('ws://' + window.location.hostname + ':' + window.Genie.Settings.websockets_port);
   var channels = Genie.WebChannels;
 
   channels.channel = socket;


### PR DESCRIPTION
This is a fix to make Genie runnable on AWS EC2 instances (for more details, please refer to #274 )