### PR TITLE
Support single-port mode for http and websocket

### DIFF
--- a/files/embedded/channels.js
+++ b/files/embedded/channels.js
@@ -1,6 +1,7 @@
 Genie.WebChannels = {};
 Genie.WebChannels.load_channels = function() {
-  var socket = new WebSocket('ws://' + window.location.hostname + ':' +  window.location.port);
+  let port = Genie.Settings.websockets_port == Genie.Settings.server_port ? window.location.port : Genie.Settings.websockets_port
+  var socket = new WebSocket('ws://' + window.location.hostname + ':' +  port);
   var channels = Genie.WebChannels;
 
   channels.channel = socket;

--- a/files/embedded/channels.js
+++ b/files/embedded/channels.js
@@ -1,6 +1,6 @@
 Genie.WebChannels = {};
 Genie.WebChannels.load_channels = function() {
-  var socket = new WebSocket('ws://' + window.location.hostname + ':' + window.Genie.Settings.websockets_port);
+  var socket = new WebSocket('ws://' + window.location.hostname + ':' +  window.location.port);
   var channels = Genie.WebChannels;
 
   channels.channel = socket;

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -226,7 +226,7 @@ mutable struct Settings
             run_as_server = false,
 
             websockets_server = false,
-            websockets_port   = server_port + 1,
+            websockets_port   = server_port,
 
             initializers_folder = "initializers",
 

--- a/src/Deploy.jl
+++ b/src/Deploy.jl
@@ -23,7 +23,7 @@ Generates a `Dockerfile` optimised for containerizing Genie apps.
 """
 function dockerfile(path::String = "."; filename::String = "Dockerfile", user::String = "genie", env::String = "dev",
                     host = "127.0.0.1", port::Int = 8000, dockerport::Int = 80, force::Bool = false,
-                    websockets_port::Int = 8001, websockets_dockerport::Int = 8001)
+                    websockets_port::Int = port, websockets_dockerport::Int = dockerport)
   filename = normpath(joinpath(path, filename))
   isfile(filename) && force && rm(filename)
   isfile(filename) && error("File $(filename) already exists. Use the `force = true` option to overwrite the existing file.")
@@ -69,7 +69,7 @@ Runs the Docker container named `containername`, binding `hostport` and `contain
 """
 function run(; containername::String = "genieapp", hostport::Int = 80, containerport::Int = 8000, appdir::String = "/home/genie/app",
                 mountapp::Bool = false, image::String = "genie", command::String = "bin/server", rm::Bool = true, it::Bool = true,
-                websockets_hostport::Int = 8001, websockets_containerport::Int = 8001)
+                websockets_hostport::Int = hostport, websockets_containerport::Int = containerport)
   options = []
   it && push!(options, "-it")
   rm && push!(options, "--rm")

--- a/src/FileTemplates.jl
+++ b/src/FileTemplates.jl
@@ -89,13 +89,13 @@ end
 """
     dockerfile(; user::String = "genie", supervisor::Bool = false, nginx::Bool = false, env::String = "dev",
                       filename::String = "Dockerfile", port::Int = 8000, dockerport::Int = 80, host::String = "0.0.0.0",
-                      websockets_port::Int = 8001, websockets_dockerport::Int = 8001)
+                      websockets_port::Int = port, websockets_dockerport::Int = dockerport)
 
 Generates dockerfile for the Genie app.
 """
 function dockerfile(; user::String = "genie", supervisor::Bool = false, nginx::Bool = false, env::String = "dev",
                       filename::String = "Dockerfile", port::Int = 8000, dockerport::Int = 80, host::String = "0.0.0.0",
-                      websockets_port::Int = 8001, websockets_dockerport::Int = 8001)
+                      websockets_port::Int = port, websockets_dockerport::Int = dockerport)
   appdir = "/home/$user/app"
 
   """

--- a/test/tests_Assets.jl
+++ b/test/tests_Assets.jl
@@ -13,7 +13,7 @@
   @safetestset "Expose settings" begin
     using Genie, Genie.Assets
 
-    @test js_settings() == "window.Genie = {};\nGenie.Settings = {\"webchannels_autosubscribe\":true,\"server_host\":\"127.0.0.1\",\"webchannels_subscribe_channel\":\"subscribe\",\"server_port\":8000,\"webchannels_default_route\":\"__\",\"webchannels_unsubscribe_channel\":\"unsubscribe\",\"websockets_port\":8001}\n"
+    @test js_settings() == "window.Genie = {};\nGenie.Settings = {\"webchannels_autosubscribe\":true,\"server_host\":\"127.0.0.1\",\"webchannels_subscribe_channel\":\"subscribe\",\"server_port\":8000,\"webchannels_default_route\":\"__\",\"webchannels_unsubscribe_channel\":\"unsubscribe\",\"websockets_port\":8000}\n"
   end
 
   @safetestset "Embedded assets" begin

--- a/test/tests_config.jl
+++ b/test/tests_config.jl
@@ -4,8 +4,17 @@
 
     @test Genie.config.server_port  == 8000
     @test Genie.config.server_host  == "127.0.0.1"
-    @test Genie.config.websockets_port == 8001
+    @test Genie.config.websockets_port == 8000
     @test Genie.config.run_as_server   == false
+
+    up(9000, "0.0.0.0")
+
+    @test Genie.config.server_port  == 9000
+    @test Genie.config.server_host  == "0.0.0.0"
+    @test Genie.config.websockets_port == 9000
+    @test Genie.config.run_as_server   == false
+
+    down()
 
     up(9000, "0.0.0.0", ws_port = 9999)
 
@@ -18,7 +27,7 @@
 
     Genie.config.server_port  = 8000
     Genie.config.server_host  = "127.0.0.1"
-    Genie.config.websockets_port = 8001
+    Genie.config.websockets_port = 8000
     Genie.config.run_as_server   = false
 
     down()


### PR DESCRIPTION
Here is a PR that addresses issues #274 and #276 
It is based on @EricForgy 's input, thanks a lot!

I adapted the tests and set the default to single-port mode.

`startup()` without arguments reads the port specification from the configuration file.
`startup(port)` sets both http and ws to port.

To provide old mode compatibility, `startup(port, ws_port=8001)` allows for separate ws_port specification.