### PR TITLE
allow for explicit channel specification; adapt security of ws protocol to http

### DIFF
--- a/files/embedded/channels.js
+++ b/files/embedded/channels.js
@@ -1,7 +1,7 @@
 Genie.WebChannels = {};
 Genie.WebChannels.load_channels = function() {
-  let port = Genie.Settings.websockets_port == Genie.Settings.server_port ? window.location.port : Genie.Settings.websockets_port
-  var socket = new WebSocket('ws://' + window.location.hostname + ':' +  port);
+  let port = Genie.Settings.websockets_port == Genie.Settings.server_port ? window.location.port : Genie.Settings.websockets_port;
+  var socket = new WebSocket(window.location.protocol.replace("http", "ws") + '//' + window.location.hostname + ':' +  port);
   var channels = Genie.WebChannels;
 
   channels.channel = socket;


### PR DESCRIPTION
This refers to [Stipple's Issue 10](https://github.com/GenieFramework/Stipple.jl/issues/10).
It allows for multiple instances of the same dashboard by explicitly specifying a ws channel.

The first commit adapts the security of the ws-protocol to that of the http protocol in the javascript backend, i.e. uses wss if https is used. This is of advantage when a loadbalancer handles the security protocol and forwards the unencrypted stream to the julia server.