### PR TITLE
Correct integer type for 32bit architectures

### DIFF
--- a/src/Input.jl
+++ b/src/Input.jl
@@ -137,7 +137,7 @@ end
 
 ###
 
-function get_multiform_parts!(http_data::Vector{UInt8}, formParts::Array{HttpFormPart}, boundary, boundaryLength::Int64 = length(boundary))
+function get_multiform_parts!(http_data::Vector{UInt8}, formParts::Array{HttpFormPart}, boundary, boundaryLength::Int = length(boundary))
   ### Go through each byte of data, parsing it into POST data and files.
 
   # According to the spec, the boundary chosen by the client must be a unique string
@@ -154,7 +154,7 @@ function get_multiform_parts!(http_data::Vector{UInt8}, formParts::Array{HttpFor
   foundBoundary::Bool = false
   foundFinalBoundary::Bool = false
 
-  bytes::Int64 = length(http_data)
+  bytes::Int = length(http_data)
 
   byteIndexOffset::Int = 0
   testIndex::Int = 1


### PR DESCRIPTION
Hi,

most of Genie.jl worked out-of-the-box on my Raspberry Pi 3b+, as soon as I was using it from a Docker container with Julia-1.5 readily built for ARMv7: https://discourse.julialang.org/t/have-a-try-julia-v1-5-1-for-arm32bit/45558

However, one thing that broke was the routing of POST requests. Turns out that `Input.get_multiform_parts!` defines an `Int64` parameter, but 32 bit architectures pass an `Int32` value to this method. Changing the parameter to `Int` (which translates to either `Int64` or `Int32` depending on the architecture) fixed the issue.

I checked with `grep -n Int64 $(find . -name "*.jl")` that there is no other occurence of `Int64` in the code base.