### PR TITLE
Bugfix: Check for config/secrets.jl before opening

### DIFF
--- a/src/genie_module.jl
+++ b/src/genie_module.jl
@@ -140,7 +140,7 @@ function load_configurations(root_dir::String = Genie.config.path_config; contex
 
   # check that the secrets_path has called Genie.secret_token!
   if isempty(Genie.secret_token(false)) # do not generate a temporary token in this check
-    match_deprecated = match(r"SECRET_TOKEN\s*=\s*\"(.*)\"", readline(secrets_path))
+    match_deprecated = isfile(secrets_path) && match(r"SECRET_TOKEN\s*=\s*\"(.*)\"", readline(secrets_path))
     if match_deprecated != nothing # does the file use the deprecated syntax?
       Genie.secret_token!(match_deprecated.captures[1]) # resolve the issue for now
       @warn "


### PR DESCRIPTION
Before checking whether config/secrets.jl is using deprecated file syntax, make sure the file exists.

Without this check any app that has no config/secrets.jl file will cause an error on load (since the file doesn't exist), rather than generating a temporary token.

Bugfix to #312 which improved the config/secrets.jl file structure.