### PR TITLE
match_deprecated should resolve to nothing, not false, if secrets file is missing

### DIFF
--- a/src/genie_module.jl
+++ b/src/genie_module.jl
@@ -141,16 +141,18 @@ function load_configurations(root_dir::String = Genie.config.path_config; contex
   # check that the secrets_path has called Genie.secret_token!
   if isempty(Genie.secret_token(false)) # do not generate a temporary token in this check
     match_deprecated = isfile(secrets_path) ? match(r"SECRET_TOKEN\s*=\s*\"(.*)\"", readline(secrets_path)) : nothing
-    if match_deprecated != nothing # does the file use the deprecated syntax?
+    if match_deprecated !== nothing # does the file use the deprecated syntax?
       Genie.secret_token!(match_deprecated.captures[1]) # resolve the issue for now
       @warn "
         $(secrets_path) is using a deprecated syntax to set the secret token.
         Call Genie.Generator.migrate_secrets_file() to resolve this warning.
       "
     end
+        
     Genie.secret_token() # emits a warning and re-generates the token if secrets_path is not valid
   end
-  return nothing
+    
+  nothing
 end
 
 

--- a/src/genie_module.jl
+++ b/src/genie_module.jl
@@ -140,7 +140,7 @@ function load_configurations(root_dir::String = Genie.config.path_config; contex
 
   # check that the secrets_path has called Genie.secret_token!
   if isempty(Genie.secret_token(false)) # do not generate a temporary token in this check
-    match_deprecated = isfile(secrets_path) && match(r"SECRET_TOKEN\s*=\s*\"(.*)\"", readline(secrets_path))
+    match_deprecated = isfile(secrets_path) ? match(r"SECRET_TOKEN\s*=\s*\"(.*)\"", readline(secrets_path)) : nothing
     if match_deprecated != nothing # does the file use the deprecated syntax?
       Genie.secret_token!(match_deprecated.captures[1]) # resolve the issue for now
       @warn "


### PR DESCRIPTION
This fixes a mistake I made in #315 , whoops.

#315 used a short circuit to check for the file, but the subsequent check compares `match_deprecated` against `nothing` not against false (which is what the short-circuit will return). Easily fixed by replacing with a ternary that returns nothing if the secrets file doesn't exist.