### PR TITLE
suppport non-string attribute values in `attributes()`

### DIFF
--- a/src/renderers/Html.jl
+++ b/src/renderers/Html.jl
@@ -140,7 +140,7 @@ function attributes(attrs::Vector{Pair{Symbol,Any}} = Vector{Pair{Symbol,Any}}()
       print(a, "$(k |> parseattr) ")
     elseif v isa AbstractString
       print(a, "$(k |> parseattr)=\"$(v)\" ")
-    elseif typeof(v) == Genie.Renderer.Json.JSONParser.JSONText
+    elseif v isa Genie.Renderer.Json.JSONParser.JSONText
       if startswith(v.s, ":")
         print(a, ":$(k |> parseattr)=$(v.s[2:end]) ")
       else

--- a/src/renderers/Html.jl
+++ b/src/renderers/Html.jl
@@ -138,8 +138,12 @@ function attributes(attrs::Vector{Pair{Symbol,Any}} = Vector{Pair{Symbol,Any}}()
 
     if (isa(v, Bool) && v) || isempty(string(v))
       print(a, "$(k |> parseattr) ")
-    else
+    elseif typeof(v) <: AbstractString
       print(a, "$(k |> parseattr)=\"$(v)\" ")
+    elseif typeof(v) == Genie.Renderer.Json.JSONParser.JSONText
+      print(a, "$(k |> parseattr)=$(v.s) ")
+    else
+      print(a, "$(k |> parseattr)=$(v) ")
     end
   end
 

--- a/src/renderers/Html.jl
+++ b/src/renderers/Html.jl
@@ -138,7 +138,7 @@ function attributes(attrs::Vector{Pair{Symbol,Any}} = Vector{Pair{Symbol,Any}}()
 
     if (isa(v, Bool) && v) || isempty(string(v))
       print(a, "$(k |> parseattr) ")
-    elseif typeof(v) <: AbstractString
+    elseif v isa AbstractString
       print(a, "$(k |> parseattr)=\"$(v)\" ")
     elseif typeof(v) == Genie.Renderer.Json.JSONParser.JSONText
       if startswith(v.s, ":")

--- a/src/renderers/Html.jl
+++ b/src/renderers/Html.jl
@@ -141,7 +141,11 @@ function attributes(attrs::Vector{Pair{Symbol,Any}} = Vector{Pair{Symbol,Any}}()
     elseif typeof(v) <: AbstractString
       print(a, "$(k |> parseattr)=\"$(v)\" ")
     elseif typeof(v) == Genie.Renderer.Json.JSONParser.JSONText
-      print(a, "$(k |> parseattr)=$(v.s) ")
+      if startswith(v.s, ":")
+        print(a, ":$(k |> parseattr)=$(v.s[2:end]) ")
+      else
+        print(a, "$(k |> parseattr)=$(v.s) ")
+      end
     else
       print(a, "$(k |> parseattr)=$(v) ")
     end


### PR DESCRIPTION
Currently, `Genie.Renderer.Html.attributes()` always prints all attribute values with double quotes.

In some situations, however, vue components require numbers or boolean values or objects to be supplied. Hence I propose to modify the routine to only surround string types with double quotes. Furthermore, it accepts JSONText to suppress the quotes explicitly.

This is the corresponding PR to #329 