### PR TITLE
normal_element: __ replacement and keyword `children`

### DIFF
--- a/src/renderers/Html.jl
+++ b/src/renderers/Html.jl
@@ -75,6 +75,16 @@ function normal_element(children::Union{String,Vector{String}}, elem::Any, args:
 end
 function normal_element(children::Union{String,Vector{String}}, elem::Any, args::Vector = [], attrs::Vector{Pair{Symbol,Any}} = Pair{Symbol,Any}[]) :: HTMLString
   children = join(children)
+
+  idx = findfirst(x -> x == :inner, getindex.(attrs, 1))
+  if !isnothing(idx)
+    children *= string(attrs[idx][2])
+    deleteat!(attrs, idx)
+  end
+  
+  ii = (x -> x isa Symbol && occursin("__", "$x")).(args)
+  args[ii] .= Symbol.(replace.(string.(args[ii]), Ref("__"=>"-")))
+
   elem = normalize_element(string(elem))
   attribs = rstrip(attributes(attrs))
   string("<", elem, (isempty(attribs) ? "" : " $attribs"), (isempty(args) ? "" : " $(join(args, " "))"), ">", prepare_template(children), "</", elem, ">")


### PR DESCRIPTION
I came across the situation where the `btn` API did not provide the possibility to supply a child element, although it is necessary to supply one if you are using slots. So I changed the interface to accept a keyword `inner` to which the elements can be attached.
Then I thought it would be nice to generalise this behaviour, because sometimes you want to first supply all the attributes and the children. So this keyword could give us the opportunity to place the children wherever we like.

Furthermore I propose to replace "__"=>"-" for symbol arguments, which makes it easy to supply empty keywords.

```
julia> btn("hello", :hello__world, "hello__world", inner=span("test"))
"<template><q-btn label=\"hello\" hello-world hello__world><span>test</span></q-btn></template>"

julia> StippleUI.banner("Banner: ", :hello__world, "hello__world", inner=span("test"))
"<template><q-banner hello-world hello__world>Banner: <span>test</span></q-banner></template>"
```
We could also name it children instead of `inner`.
@essenciary What do you think?