### PR TITLE
Don't run CompatHelper for opened issues

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -3,7 +3,7 @@ name: CompatHelper
 on:
   schedule:
     - cron: '00 * * * *'
-  issues:
+  pull_request:
     types: [opened, reopened]
 
 jobs:


### PR DESCRIPTION
Previously opening an issue would trigger CompatHelper.jl and I'd get an email about it. Now it should only happen for pull requests. I'm not sure why I'm getting emails anyway but at least this should be an improvement.