### PR TITLE
Include function is missing a close bracket

### DIFF
--- a/docs/src/tutorials/4-1--Developing_MVC_Web_Apps.md
+++ b/docs/src/tutorials/4-1--Developing_MVC_Web_Apps.md
@@ -57,7 +57,7 @@ dev:
 Now let's manually load the database configuration:
 
 ```julia
-julia> include(joinpath("config", "initializers", "searchlight.jl")
+julia> include(joinpath("config", "initializers", "searchlight.jl"))
 SQLite.DB("db/netflix_catalog.sqlite")
 ```
 


### PR DESCRIPTION
The call to `include(joinpath("config", "initializers", "searchlight.jl") ` is technically missing a close parenthesis. 

This is actually pretty confusing, because the very next line appears to be another statement, but does not begin with the julia REPL prompt, indicating that perhaps this line in intended to be included as a parameter in the previous line's function call? It's unclear. 

Having run through the process, clearly the `SQLight.DB(...)` is just the output of the REPL after completing the command, but just reading it, it's not so obvious. 

Thanks for considering this clarification :)