### PR TITLE
fix missing quotes for bound symbols

### DIFF
--- a/src/renderers/Html.jl
+++ b/src/renderers/Html.jl
@@ -148,7 +148,7 @@ function attributes(attrs::Vector{Pair{Symbol,Any}} = Vector{Pair{Symbol,Any}}()
 
     if (isa(v, Bool) && v) || isempty(string(v))
       print(a, "$(k |> parseattr) ")
-    elseif v isa AbstractString
+    elseif v isa AbstractString || v isa Symbol
       print(a, "$(k |> parseattr)=\"$(v)\" ")
     elseif v isa Genie.Renderer.Json.JSONParser.JSONText
       if startswith(v.s, ":")


### PR DESCRIPTION
before the fix:
```
julia> xelem(:test, "hh";  rules=Symbol("test me") )
"<template><test :rules=test me>hh</test></template>"
```
after the fix
```
julia> xelem(:test, "hh";  rules=Symbol("test me") )
"<template><test :rules=\"test me\">hh</test></template>"
```