### PR TITLE
Add character ':' to parse_route validation_match

### DIFF
--- a/src/Router.jl
+++ b/src/Router.jl
@@ -570,7 +570,7 @@ function parse_route(route::String; context::Module = @__MODULE__) :: Tuple{Stri
   param_types = Any[]
 
   if occursin('#', route) || occursin(':', route)
-    validation_match = "[\\w\\-\\.\\+\\,\\s\\%]+"
+    validation_match = "[\\w\\-\\.\\+\\,\\s\\%\\:]+"
 
     for rp in split(route, '/', keepempty = false)
       if occursin("#", rp)


### PR DESCRIPTION
### Reference issue: https://github.com/GenieFramework/Genie.jl/issues/418

Minor change which intends to include the character `:` to the list of valid characters a dynamic route parameter can have, it is done by modifying the `validation_match` variable in the function `Genie.Router.parse_route`. 