### PR TITLE
Adding dynamic function signature to each and every function in the package for better documentation.

### DIFF
--- a/files/new_app/app/helpers/ValidationHelper.jl
+++ b/files/new_app/app/helpers/ValidationHelper.jl
@@ -4,6 +4,9 @@ using Genie, SearchLight, SearchLight.Validation
 
 export output_errors
 
+"""
+$TYPEDSIGNATURES
+"""
 function output_errors(m::T, field::Symbol)::String where {T<:SearchLight.AbstractModel}
   v = ispayload() ? validate(m) : ModelValidator()
 

--- a/files/new_app/app/helpers/ViewHelper.jl
+++ b/files/new_app/app/helpers/ViewHelper.jl
@@ -4,6 +4,9 @@ using Genie, Genie.Flash, Genie.Router
 
 export output_flash
 
+"""
+$TYPEDSIGNATURES
+"""
 function output_flash(flashtype::String = "danger") :: String
   flash_has_message() ? """<div class="alert alert-$flashtype alert-dismissable">$(flash())</div>""" : ""
 end

--- a/files/new_app/config/initializers/logging.jl
+++ b/files/new_app/config/initializers/logging.jl
@@ -2,6 +2,9 @@ import Genie
 import Logging, LoggingExtras
 import Dates
 
+"""
+$TYPEDSIGNATURES
+"""
 function initialize_logging()
   date_format = "yyyy-mm-dd HH:MM:SS"
 

--- a/files/new_app/config/initializers/searchlight.jl
+++ b/files/new_app/config/initializers/searchlight.jl
@@ -10,10 +10,16 @@ try
     @eval begin
       using Genie.Renderer.Json
 
+      """      
+      $TYPEDSIGNATURES
+      """
       function Genie.Renderer.Json.JSON3.StructTypes.StructType(::Type{T}) where {T<:SearchLight.AbstractModel}
         Genie.Renderer.Json.JSON3.StructTypes.Struct()
       end
 
+      """      
+      $TYPEDSIGNATURES
+      """
       function Genie.Renderer.Json.JSON3.StructTypes.StructType(::Type{SearchLight.DbId})
         Genie.Renderer.Json.JSON3.StructTypes.Struct()
       end

--- a/files/new_app/config/initializers/ssl.jl
+++ b/files/new_app/config/initializers/ssl.jl
@@ -1,5 +1,8 @@
 using Genie, MbedTLS
 
+"""
+$TYPEDSIGNATURES
+"""
 function configure_dev_ssl()
   cert = Genie.Assets.embedded_path(joinpath("files", "ssl", "localhost.crt")) |> MbedTLS.crt_parse_file
   key = Genie.Assets.embedded_path(joinpath("files", "ssl", "localhost.key")) |> MbedTLS.parse_keyfile

--- a/src/App.jl
+++ b/src/App.jl
@@ -2,6 +2,7 @@
 App level functionality -- loading and managing app-wide components like configs, models, initializers, etc.
 """
 module App
+using DocStringExtensionsMock
 
 import Genie
 
@@ -10,7 +11,7 @@ import Genie
 
 
 """
-    bootstrap(context::Union{Module,Nothing} = nothing) :: Nothing
+$TYPEDSIGNATURES
 
 Kickstarts the loading of a Genie app by loading the environment settings.
 """

--- a/src/AppServer.jl
+++ b/src/AppServer.jl
@@ -2,6 +2,7 @@
 Handles Http server related functionality, manages requests and responses and their logging.
 """
 module AppServer
+using DocStringExtensionsMock
 
 using HTTP, Sockets
 import Millboard, Distributed, Logging, MbedTLS
@@ -44,8 +45,7 @@ const SERVERS = ServersCollection(nothing, nothing)
 # end
 
 """
-    startup(port::Int = Genie.config.server_port, host::String = Genie.config.server_host;
-        ws_port::Int = Genie.config.websockets_port, async::Bool = ! Genie.config.run_as_server) :: ServersCollection
+$TYPEDSIGNATURES
 
 Starts the web server.
 
@@ -149,6 +149,9 @@ function startup(port::Int, host::String = Genie.config.server_host;
   SERVERS
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function startup(; port = Genie.config.server_port, ws_port = Genie.config.websockets_port, kwargs...) :: ServersCollection
     startup(port; ws_port = ws_port, kwargs...)
 end
@@ -169,7 +172,7 @@ end
 
 
 """
-    update_config(port::Int, host::String, ws_port::Int) :: Nothing
+$TYPEDSIGNATURES
 
 Updates the corresponding Genie configurations to the corresponding values for
   `port`, `host`, and `ws_port`, if these are passed as arguments when starting up the server.
@@ -184,7 +187,7 @@ end
 
 
 """
-    down(; webserver::Bool = true, websockets::Bool = true) :: ServersCollection
+$TYPEDSIGNATURES
 
 Shuts down the servers optionally indicating which of the `webserver` and `websockets` servers to be stopped.
 """
@@ -197,7 +200,7 @@ end
 
 
 """
-    handle_request(req::HTTP.Request, res::HTTP.Response) :: HTTP.Response
+$TYPEDSIGNATURES
 
 Http server handler function - invoked when the server gets a request.
 """
@@ -216,6 +219,9 @@ function handle_request(req::HTTP.Request, res::HTTP.Response) :: HTTP.Response
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function setup_http_streamer(http::HTTP.Stream)
   if Genie.config.features_peerinfo
     try
@@ -230,7 +236,7 @@ end
 
 
 """
-    setup_http_listener(req::HTTP.Request, res::HTTP.Response = HTTP.Response()) :: HTTP.Response
+$TYPEDSIGNATURES
 
 Configures the handler for the HTTP Request and handles errors.
 """
@@ -260,7 +266,7 @@ end
 
 
 """
-    setup_ws_handler(req::HTTP.Request, ws_client) :: Nothing
+$TYPEDSIGNATURES
 
 Configures the handler for WebSockets requests.
 """
@@ -282,7 +288,7 @@ end
 
 
 """
-    handle_ws_request(req::HTTP.Request, msg::String, ws_client) :: String
+$TYPEDSIGNATURES
 
 Http server handler function - invoked when the server gets a request.
 """

--- a/src/Assets.jl
+++ b/src/Assets.jl
@@ -2,6 +2,7 @@
 Helper functions for working with frontend assets (including JS, CSS, etc files).
 """
 module Assets
+using DocStringExtensionsMock
 
 import Genie, Genie.Configuration, Genie.Router, Genie.WebChannels, Genie.WebThreads
 import Genie.Renderer.Json
@@ -15,7 +16,7 @@ export favicon_support
 
 
 """
-    include_asset(asset_type::Union{String,Symbol}, file_name::Union{String,Symbol}) :: String
+$TYPEDSIGNATURES
 
 Returns the path to an asset. `asset_type` can be one of `:js`, `:css`. The `file_name` should not include the extension.
 """
@@ -25,7 +26,7 @@ end
 
 
 """
-    css_asset(file_name::String) :: String
+$TYPEDSIGNATURES
 
 Path to a css asset. The `file_name` should not include the extension.
 """
@@ -36,7 +37,7 @@ const css = css_asset
 
 
 """
-    js_asset(file_name::String) :: String
+$TYPEDSIGNATURES
 
 Path to a js asset. `file_name` should not include the extension.
 """
@@ -47,7 +48,7 @@ const js = js_asset
 
 
 """
-    js_settings() :: string
+$TYPEDSIGNATURES
 
 Sets up a `window.Genie.Settings` JavaScript object which exposes relevant Genie app settings from `Genie.config`
 """
@@ -80,7 +81,7 @@ end
 
 
 """
-    embeded(path::String) :: String
+$TYPEDSIGNATURES
 
 Reads and outputs the file at `path` within Genie's root package dir
 """
@@ -90,7 +91,7 @@ end
 
 
 """
-    embeded_path(path::String) :: String
+$TYPEDSIGNATURES
 
 Returns the path relative to Genie's root package dir
 """
@@ -100,7 +101,7 @@ end
 
 
 """
-    channels() :: String
+$TYPEDSIGNATURES
 
 Outputs the channels.js file included with the Genie package
 """
@@ -110,7 +111,7 @@ end
 
 
 """
-    channels_script() :: String
+$TYPEDSIGNATURES
 
 Outputs the channels JavaScript content within `<script>...</script>` tags, for embedding into the page.
 """
@@ -123,6 +124,9 @@ $(channels(channel))
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function channels_subscribe(channel::String = Genie.config.webchannels_default_route) :: Nothing
   Router.channel("/$(channel)/$(Genie.config.webchannels_subscribe_channel)") do
     WebChannels.subscribe(Genie.Requests.wsclient(), channel)
@@ -142,7 +146,7 @@ end
 
 
 """
-    channels_support(channel = Genie.config.webchannels_default_route) :: String
+$TYPEDSIGNATURES
 
 Provides full web channels support, setting up routes for loading support JS files, web sockets subscription and
 returning the `<script>` tag for including the linked JS file into the web page.
@@ -165,7 +169,7 @@ end
 
 
 """
-    webthreads() :: String
+$TYPEDSIGNATURES
 
 Outputs the webthreads.js file included with the Genie package
 """
@@ -177,7 +181,7 @@ end
 
 
 """
-    webthreads_script() :: String
+$TYPEDSIGNATURES
 
 Outputs the channels JavaScript content within `<script>...</script>` tags, for embedding into the page.
 """
@@ -190,6 +194,9 @@ $(webthreads(channel))
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function webthreads_subscribe(channel::String = Genie.config.webthreads_default_route) :: Nothing
   Router.route("/$(channel)/$(Genie.config.webchannels_subscribe_channel)", method = Router.GET) do
     WebThreads.subscribe(Genie.Requests.wtclient(), channel)
@@ -208,6 +215,9 @@ function webthreads_subscribe(channel::String = Genie.config.webthreads_default_
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function webthreads_push_pull(channel::String = Genie.config.webthreads_default_route) :: Nothing
   Router.route("/$(channel)/$(Genie.config.webthreads_pull_route)", method = Router.POST) do
     WebThreads.pull(Genie.Requests.wtclient(), channel)
@@ -222,7 +232,7 @@ end
 
 
 """
-    webthreads_support(channel = Genie.config.webthreads_default_route) :: String
+$TYPEDSIGNATURES
 
 Provides full web channels support, setting up routes for loading support JS files, web sockets subscription and
 returning the `<script>` tag for including the linked JS file into the web page.
@@ -247,7 +257,7 @@ end
 
 
 """
-    favicon_support() :: String
+$TYPEDSIGNATURES
 
 Outputs the `<link>` tag for referencing the favicon file embedded with Genie.
 """

--- a/src/Cache.jl
+++ b/src/Cache.jl
@@ -2,6 +2,7 @@
 Caching functionality for Genie.
 """
 module Cache
+using DocStringExtensionsMock
 
 import SHA, Logging
 import Genie
@@ -10,6 +11,9 @@ export cachekey, withcache, @cache
 export purge, purgeall
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function init() :: Nothing
   @eval Genie.config.cache_storage === nothing && (Genie.config.cache_storage = :File)
   @eval Genie.config.cache_storage == :File && include(joinpath(@__DIR__, "cache_adapters", "FileCache.jl"))
@@ -19,7 +23,7 @@ end
 
 
 """
-    withcache(f::Function, key::Union{String,Symbol}, expiration::Int = Genie.config.cache_duration; dir = "", condition::Bool = true)
+$TYPEDSIGNATURES
 
 Executes the function `f` and stores the result into the cache for the duration (in seconds) of `expiration`. Next time the function is invoked,
 if the cache has not expired, the cached result is returned skipping the function execution.
@@ -30,7 +34,7 @@ function withcache end
 
 
 """
-    purge()
+$TYPEDSIGNATURES
 
 Removes the cache data stored under the `key` key.
 """
@@ -38,7 +42,7 @@ function purge end
 
 
 """
-    purgeall()
+$TYPEDSIGNATURES
 
 Removes all cached data.
 """
@@ -58,7 +62,7 @@ end
 
 
 """
-    cachekey(args...) :: String
+$TYPEDSIGNATURES
 
 Computes a unique cache key based on `args`. Used to generate unique `key`s for storing data in cache.
 """

--- a/src/Commands.jl
+++ b/src/Commands.jl
@@ -2,6 +2,7 @@
 Handles command line arguments for the genie.jl script.
 """
 module Commands
+using DocStringExtensionsMock
 
 import Sockets
 import ArgParse
@@ -9,7 +10,7 @@ import Genie
 using Logging
 
 """
-    execute(config::Settings) :: Nothing
+$TYPEDSIGNATURES
 
 Runs the requested Genie app command, based on the `args` passed to the script.
 """
@@ -50,7 +51,7 @@ end
 
 
 """
-    parse_commandline_args() :: Dict{String,Any}
+$TYPEDSIGNATURES
 
 Extracts the command line args passed into the app and returns them as a `Dict`, possibly setting up defaults.
 Also, it is used by the ArgParse module to populate the command line help for the app `-h`.
@@ -93,7 +94,7 @@ end
 
 
 """
-    called_command(args::Dict, key::String) :: Bool
+$TYPEDSIGNATURES
 
 Checks whether or not a certain command was invoked by looking at the command line args.
 """

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -2,6 +2,7 @@
 Core genie configuration / settings functionality.
 """
 module Configuration
+using DocStringExtensionsMock
 
 import Pkg
 import Dates

--- a/src/Cookies.jl
+++ b/src/Cookies.jl
@@ -2,13 +2,14 @@
 Functionality for dealing with HTTP cookies.
 """
 module Cookies
+using DocStringExtensionsMock
 
 import HTTP
 import Genie, Genie.Encryption, Genie.HTTPUtils
 
 
 """
-    get(payload::Union{HTTP.Response,HTTP.Request}, key::Union{String,Symbol}, default::T; encrypted::Bool = true)::T where T
+$TYPEDSIGNATURES
 
 Attempts to get the Cookie value stored at `key` within `payload`.
 If the `key` is not set, the `default` value is returned.
@@ -26,7 +27,7 @@ end
 
 
 """
-    get(res::HTTP.Response, key::Union{String,Symbol}) :: Union{Nothing,String}
+$TYPEDSIGNATURES
 
 Retrieves a value stored on the cookie as `key` from the `Respose` object.
 
@@ -43,7 +44,7 @@ end
 
 
 """
-    get(req::Request, key::Union{String,Symbol}) :: Union{Nothing,String}
+$TYPEDSIGNATURES
 
 Retrieves a value stored on the cookie as `key` from the `Request` object.
 
@@ -60,7 +61,7 @@ end
 
 
 """
-    set!(res::HTTP.Response, key::Union{String,Symbol}, value::Any, attributes::Dict; encrypted::Bool = true) :: HTTP.Response
+$TYPEDSIGNATURES
 
 Sets `value` under the `key` label on the `Cookie`.
 
@@ -96,7 +97,7 @@ end
 
 
 """
-    Dict(req::Request) :: Dict{String,String}
+$TYPEDSIGNATURES
 
 Extracts the `Cookie` and `Set-Cookie` data from the `Request` and `Response` objects and converts it into a Dict.
 """
@@ -133,7 +134,7 @@ end
 
 
 """
-    nullablevalue(payload::Union{HTTP.Response,HTTP.Request}, key::Union{String,Symbol}; encrypted::Bool = true)
+$TYPEDSIGNATURES
 
 Attempts to retrieve a cookie value stored at `key` in the `payload object` and returns a `Union{Nothing,String}`
 
@@ -158,7 +159,7 @@ end
 
 
 """
-    getcookies(req::HTTP.Request) :: Vector{HTTP.Cookies.Cookie}
+$TYPEDSIGNATURES
 
 Extracts cookies from within `req`
 """
@@ -168,7 +169,7 @@ end
 
 
 """
-    getcookies(req::HTTP.Request) :: Vector{HTTP.Cookies.Cookie}
+$TYPEDSIGNATURES
 
 Extracts cookies from within `req`, filtering them by `matching` name.
 """

--- a/src/Deploy.jl
+++ b/src/Deploy.jl
@@ -1,6 +1,9 @@
 module Deploy
+using DocStringExtensionsMock
 
-
+"""
+$TYPEDSIGNATURES
+"""
 function run(command::Cmd)
   try Base.run(command)
 
@@ -15,14 +18,14 @@ end
 
 
 module Docker
+using DocStringExtensionsMock
 
 import Genie, Genie.FileTemplates
 
 const DOCKER = @static Sys.islinux() ? `sudo docker` : `docker`
 
 """
-    dockerfile(path::String = "."; user::String = "genie", env::String = "dev",
-              filename::String = "Dockerfile", port::Int = 8000, dockerport::Int = 80, force::Bool = false)
+$TYPEDSIGNATURES
 
 Generates a `Dockerfile` optimised for containerizing Genie apps.
 
@@ -54,7 +57,7 @@ end
 
 
 """
-    build(path::String = "."; appname = "genie")
+$TYPEDSIGNATURES
 
 Builds the Docker image based on the `Dockerfile`
 """
@@ -70,8 +73,7 @@ end
 
 
 """
-    run(; containername::String = "genieapp", hostport::Int = 80, containerport::Int = 8000, appdir::String = "/home/genie/app",
-        mountapp::Bool = false, image::String = "genie", command::String = "bin/server", rm::Bool = true, it::Bool = true)
+$TYPEDSIGNATURES
 
 Runs the Docker container named `containername`, binding `hostport` and `containerport`.
 
@@ -125,13 +127,14 @@ end # end module Docker
 ########
 
 module Heroku
+using DocStringExtensionsMock
 
 import Genie
 
 const HEROKU = @static Sys.iswindows() ? `heroku.cmd` : `heroku`
 
 """
-    apps()
+$TYPEDSIGNATURES
 
 Returns list of apps available on Heroku account.
 """
@@ -140,7 +143,7 @@ function apps()
 end
 
 """
-    createapp(appname::String; region::String = "us")
+$TYPEDSIGNATURES
 
 Runs the `heroku create` command to create a new app in the indicated region.
 See https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-apps-create-app
@@ -151,7 +154,7 @@ end
 
 
 """
-    push(appname::String; apptype::String = "web")
+$TYPEDSIGNATURES
 
 Invokes the `heroku container:push` which builds, then pushes Docker images to deploy your Heroku app.
 See https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-container-push
@@ -162,7 +165,7 @@ end
 
 
 """
-    release(appname::String; apptype::String = "web")
+$TYPEDSIGNATURES
 
 Invokes the `keroku container:release` which releases previously pushed Docker images to your Heroku app.
 See https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-container-push
@@ -173,7 +176,7 @@ end
 
 
 """
-    open(appname::String)
+$TYPEDSIGNATURES
 
 Invokes the `heroku open` command which open the app in a web browser.
 See https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-apps-open-path
@@ -184,7 +187,7 @@ end
 
 
 """
-    login()
+$TYPEDSIGNATURES
 
 Invokes the `heroku container:login` to log in to Heroku Container Registry,
 See https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-container-login
@@ -195,7 +198,7 @@ end
 
 
 """
-    logs(appname::String; lines::Int = 1_000)
+$TYPEDSIGNATURES
 
 Display recent heroku log output.
 https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-logs

--- a/src/DocStringExtensionsMock.jl
+++ b/src/DocStringExtensionsMock.jl
@@ -1,0 +1,15 @@
+module DocStringExtensionsMock
+
+#If we don' thave DocStringExtensions installed, make a fall-back that prevents an error:
+using Pkg
+#If DocStringExtensions is installed, use it:
+if Base.find_package("DocStringEstensions")!==nothing
+    using DocStringExtensions
+else
+  TYPEDSIGNATURES=""
+  SIGNATURES=""
+end
+
+export SIGNATURES, TYPEDSIGNATURES
+
+end

--- a/src/Encryption.jl
+++ b/src/Encryption.jl
@@ -2,6 +2,7 @@
 Provides Genie with encryption and decryption capabilities.
 """
 module Encryption
+using DocStringExtensionsMock
 
 import Genie, Nettle
 
@@ -9,7 +10,7 @@ const ENCRYPTION_METHOD = "AES256"
 
 
 """
-    encrypt{T}(s::T) :: String
+$TYPEDSIGNATURES
 
 Encrypts `s`.
 """
@@ -22,7 +23,7 @@ end
 
 
 """
-    decrypt(s::String) :: String
+$TYPEDSIGNATURES
 
 Decrypts `s` (a `string` previously encrypted by Genie).
 """
@@ -36,7 +37,7 @@ end
 
 
 """
-    encryption_sauce() :: Tuple{Vector{UInt8},Vector{UInt8}}
+$TYPEDSIGNATURES
 
 Generates a pair of key32 and iv16 with salt for encryption/decryption
 """

--- a/src/Exceptions.jl
+++ b/src/Exceptions.jl
@@ -1,4 +1,5 @@
 module Exceptions
+using DocStringExtensionsMock
 
 import Genie
 import HTTP

--- a/src/FileTemplates.jl
+++ b/src/FileTemplates.jl
@@ -2,12 +2,13 @@
 Functionality for handling the defautl conent of the various Genie files (migrations, models, controllers, etc).
 """
 module FileTemplates
+using DocStringExtensionsMock
 
 import Inflector
 
 
 """
-    newtask(module_name::String) :: String
+$TYPEDSIGNATURES
 
 Default content for a new Genie Toolbox task.
 """
@@ -28,7 +29,7 @@ end
 
 
 """
-    newcontroller(controller_name::String) :: String
+$TYPEDSIGNATURES
 
 Default content for a new Genie controller.
 """
@@ -42,7 +43,7 @@ end
 
 
 """
-    newtest(plural_name::String, singular_name::String) :: String
+$TYPEDSIGNATURES
 
 Default content for a new test file.
 """
@@ -57,7 +58,7 @@ end
 
 
 """
-    appmodule(path::String)
+$TYPEDSIGNATURES
 
 Generates a custom app module when a new app is bootstrapped.
 """
@@ -87,9 +88,7 @@ end
 
 
 """
-    dockerfile(; user::String = "genie", supervisor::Bool = false, nginx::Bool = false, env::String = "dev",
-                      filename::String = "Dockerfile", port::Int = 8000, dockerport::Int = 80, host::String = "0.0.0.0",
-                      websockets_port::Int = port, websockets_dockerport::Int = dockerport)
+$TYPEDSIGNATURES
 
 Generates dockerfile for the Genie app.
 """

--- a/src/Flash.jl
+++ b/src/Flash.jl
@@ -2,19 +2,23 @@
 Various utility functions for using across models, controllers and views.
 """
 module Flash
+using DocStringExtensionsMock
 
 import Genie
 
 export flash, flash_has_message
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function init()
   Genie.Sessions.init()
 end
 
 
 """
-    flash()
+$TYPEDSIGNATURES
 
 Returns the `flash` dict object associated with the current HTTP request.
 """
@@ -24,7 +28,7 @@ end
 
 
 """
-    flash(value::Any) :: Nothing
+$TYPEDSIGNATURES
 
 Stores `value` onto the flash.
 """
@@ -37,7 +41,7 @@ end
 
 
 """
-    flash_has_message() :: Bool
+$TYPEDSIGNATURES
 
 Checks if there's any value on the flash storage
 """

--- a/src/Generator.jl
+++ b/src/Generator.jl
@@ -2,6 +2,7 @@
 Generates various Genie files.
 """
 module Generator
+using DocStringExtensionsMock
 
 import SHA, Dates, Pkg, Logging, UUIDs
 import Inflector
@@ -11,13 +12,16 @@ import Genie
 const JULIA_PATH = joinpath(Sys.BINDIR, "julia")
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function validname(name::String)
   filter(! isempty, [x.match for x in collect(eachmatch(r"[0-9a-zA-Z_]*", name))]) |> join
 end
 
 
 """
-    newcontroller(resource_name::String) :: Nothing
+$TYPEDSIGNATURES
 
 Generates a new Genie controller file and persists it to the resources folder.
 """
@@ -37,7 +41,7 @@ end
 
 
 """
-    newresource(resource_name::String, config::Settings) :: Nothing
+$TYPEDSIGNATURES
 
 Generates all the files associated with a new resource and persists them to the resources folder.
 """
@@ -61,7 +65,7 @@ end
 
 
 """
-    setup_resource_path(resource_name::String) :: String
+$TYPEDSIGNATURES
 
 Computes and creates the directories structure needed to persist a new resource.
 """
@@ -80,7 +84,7 @@ end
 
 
 """
-    write_resource_file(resource_path::String, file_name::String, resource_name::String) :: Bool
+$TYPEDSIGNATURES
 
 Generates all resouce files and persists them to disk.
 """
@@ -120,6 +124,9 @@ function write_resource_file(resource_path::String, file_name::String, resource_
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function binfolderpath(path::String) :: String
   bin_folder_path = joinpath(path, Genie.config.path_bin)
   isdir(bin_folder_path) || mkpath(bin_folder_path)
@@ -129,7 +136,7 @@ end
 
 
 """
-    setup_windows_bin_files(path::String = ".") :: Nothing
+$TYPEDSIGNATURES
 
 Creates the bin/server and bin/repl binaries for Windows
 """
@@ -153,7 +160,7 @@ end
 
 
 """
-    setup_nix_bin_files(path::String = ".") :: Nothing
+$TYPEDSIGNATURES
 
 Creates the bin/server and bin/repl binaries for *nix systems
 """
@@ -181,7 +188,7 @@ end
 
 
 """
-    resource_does_not_exist(resource_path::String, file_name::String) :: Bool
+$TYPEDSIGNATURES
 
 Returns `true` if the indicated resources does not exists - false otherwise.
 """
@@ -197,7 +204,7 @@ end
 
 
 """
-    controller_file_name(resource_name::Union{String,Symbol})
+$TYPEDSIGNATURES
 
 Computes the controller file name based on the resource name.
 """
@@ -207,7 +214,7 @@ end
 
 
 """
-    secret_token() :: String
+$TYPEDSIGNATURES
 
 Generates a random secret token to be used for configuring the call to `Genie.secret_token!`.
 """
@@ -217,7 +224,7 @@ end
 
 
 """
-    write_secrets_file(app_path=".")
+$TYPEDSIGNATURES
 
 Generates a valid `config/secrets.jl` file with a random secret token.
 """
@@ -234,7 +241,7 @@ end
 
 
 """
-    fullstack_app(app_path::String = ".") :: Nothing
+$TYPEDSIGNATURES
 
 Writes the files necessary to create a full stack Genie app.
 """
@@ -248,7 +255,7 @@ end
 
 
 """
-    minimal(app_name::String, app_path::String = abspath(app_name), autostart::Bool = true) :: Nothing
+$TYPEDSIGNATURES
 
 Creates a minimal Genie app.
 """
@@ -265,7 +272,7 @@ end
 
 
 """
-    scaffold(app_path::String = ".") :: Nothing
+$TYPEDSIGNATURES
 
 Writes the file necessary to scaffold a minimal Genie app.
 """
@@ -290,7 +297,7 @@ end
 
 
 """
-    microstack_app(app_path::String = ".") :: Nothing
+$TYPEDSIGNATURES
 
 Writes the file necessary to create a microstack app.
 """
@@ -308,7 +315,7 @@ end
 
 
 """
-    mvc_support(app_path::String = ".") :: Nothing
+$TYPEDSIGNATURES
 
 Writes the files used for rendering resources using the MVC stack and the Genie templating system.
 """
@@ -320,7 +327,7 @@ end
 
 
 """
-    db_support(app_path::String = ".") :: Nothing
+$TYPEDSIGNATURES
 
 Writes files used for interacting with the SearchLight ORM.
 """
@@ -336,6 +343,9 @@ function db_support(app_path::String = ".", include_env::Bool = true, add_depend
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function db_intializer(app_path::String = ".", include_env::Bool = false)
   initializers_dir = joinpath(app_path, Genie.config.path_initializers)
   initializer_path = joinpath(initializers_dir, Genie.SEARCHLIGHT_INITIALIZER_FILE_NAME)
@@ -350,7 +360,7 @@ end
 
 
 """
-    write_app_custom_files(path::String, app_path::String) :: Nothing
+$TYPEDSIGNATURES
 
 Writes the Genie app main module file.
 """
@@ -387,7 +397,7 @@ end
 
 
 """
-    install_app_dependencies(app_path::String = ".") :: Nothing
+$TYPEDSIGNATURES
 
 Installs the application's dependencies using Julia's Pkg
 """
@@ -417,7 +427,7 @@ end
 
 
 """
-    generate_project(name)
+$TYPEDSIGNATURES
 
 Generate the `Project.toml` with a name and a uuid.
 If this file already exists, generate `Project_sample.toml` as a reference instead.
@@ -446,6 +456,9 @@ function generate_project(name::String) :: Nothing
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function pkgproject(ctx::Pkg.API.Context, pkg::String, dir::String) :: Nothing
   name = email = nothing
 
@@ -486,6 +499,9 @@ function pkgproject(ctx::Pkg.API.Context, pkg::String, dir::String) :: Nothing
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function pkggenfile(f::Function, ctx::Pkg.API.Context, pkg::String, dir::String, file::String) :: Nothing
   path = joinpath(dir, pkg, file)
   println(ctx.io, "    $(Base.contractuser(path))")
@@ -494,6 +510,9 @@ function pkggenfile(f::Function, ctx::Pkg.API.Context, pkg::String, dir::String,
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function install_db_dependencies(; testmode::Bool = false) :: Nothing
   try
     Pkg.add("SearchLight")
@@ -506,6 +525,9 @@ function install_db_dependencies(; testmode::Bool = false) :: Nothing
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function install_searchlight_dependencies() :: Nothing # TODO: move this to SearchLight post install
   backends = ["SQLite", "MySQL", "PostgreSQL"]
 
@@ -531,7 +553,7 @@ end
 
 
 """
-    autostart_app(path::String = "."; autostart::Bool = true) :: Nothing
+$TYPEDSIGNATURES
 
 If `autostart` is `true`, the newly generated Genie app will be automatically started.
 """
@@ -550,7 +572,7 @@ end
 
 
 """
-    remove_searchlight_initializer(app_path::String = ".") :: Nothing
+$TYPEDSIGNATURES
 
 Removes the SearchLight initializer file if it's unused
 """
@@ -562,7 +584,7 @@ end
 
 
 """
-    newapp(app_name::String; autostart::Bool = true, fullstack::Bool = false, dbsupport::Bool = false, mvcsupport::Bool = false) :: Nothing
+$TYPEDSIGNATURES
 
 Scaffolds a new Genie app, setting up the file structure indicated by the various arguments.
 
@@ -630,6 +652,9 @@ function newapp(app_name::String; autostart::Bool = true, fullstack::Bool = fals
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function post_create(app_name::String, app_path::String; autostart::Bool = true, testmode::Bool = false, dbsupport::Bool = false)
   @info "Done! New app created at $app_path"
 
@@ -648,6 +673,9 @@ function post_create(app_name::String, app_path::String; autostart::Bool = true,
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function set_files_mod() :: Nothing
   for f in ["Manifest.toml", "Project.toml", "routes.jl"]
     try
@@ -662,7 +690,7 @@ end
 
 
 """
-    newapp_webservice(path::String = "."; autostart::Bool = true, dbsupport::Bool = false) :: Nothing
+$TYPEDSIGNATURES
 
 Template for scaffolding a new Genie app suitable for nimble web services.
 
@@ -677,7 +705,7 @@ end
 
 
 """
-    newapp_mvc(path::String = "."; autostart::Bool = true) :: Nothing
+$TYPEDSIGNATURES
 
 Template for scaffolding a new Genie app suitable for MVC web applications (includes MVC structure and DB support).
 
@@ -691,7 +719,7 @@ end
 
 
 """
-    newapp_fullstack(path::String = "."; autostart::Bool = true) :: Nothing
+$TYPEDSIGNATURES
 
 Template for scaffolding a new Genie app suitable for full stack web applications (includes MVC structure, DB support, and frontend asset pipeline).
 

--- a/src/Genie.jl
+++ b/src/Genie.jl
@@ -3,6 +3,9 @@ Loads dependencies and bootstraps a Genie app. Exposes core Genie functionality.
 """
 module Genie
 
+include("DocStringExtensionsMock.jl")
+using .DocStringExtensionsMock
+
 import Revise
 
 push!(LOAD_PATH, @__DIR__)
@@ -58,7 +61,7 @@ export serve, up, down, loadapp, genie, bootstrap
 @reexport using .Router
 
 """
-    serve(path::String = Genie.config.server_document_root, params...; kwparams...)
+$TYPEDSIGNATURES
 
 Serves a folder of static files located at `path`. Allows Genie to be used as a static files web server.
 The `params` and `kwparams` arguments are forwarded to `Genie.startup()`.
@@ -142,7 +145,7 @@ const newapp_fullstack = Generator.newapp_fullstack
 
 
 """
-    loadapp(path::String = "."; autostart::Bool = false) :: Nothing
+$TYPEDSIGNATURES
 
 Loads an existing Genie app from the file system, within the current Julia REPL session.
 
@@ -222,7 +225,7 @@ const down = AppServer.down
 ### PRIVATE ###
 
 """
-    run() :: Nothing
+$TYPEDSIGNATURES
 
 Runs the Genie app by parsing the command line args and invoking the corresponding actions.
 Used internally to parse command line arguments.
@@ -235,7 +238,7 @@ end
 
 
 """
-    genie() :: Union{Nothing,Sockets.TCPServer}
+$TYPEDSIGNATURES
 """
 function genie(; context = @__MODULE__) :: Union{Nothing,Sockets.TCPServer}
   haskey(ENV, "GENIE_ENV") || (ENV["GENIE_ENV"] = "dev")

--- a/src/HTTPUtils.jl
+++ b/src/HTTPUtils.jl
@@ -2,12 +2,12 @@
 Genie utilities for working over HTTP.
 """
 module HTTPUtils
+using DocStringExtensionsMock
 
 import HTTP
 
-
 """
-    Base.Dict(req::HTTP.Request) :: Dict{String,String}
+$TYPEDSIGNATURES
 
 Converts a `HTTP.Request` to a `Dict`.
 """

--- a/src/Headers.jl
+++ b/src/Headers.jl
@@ -3,11 +3,12 @@ Provides functionality for working with HTTP headers in Genie.
 """
 module Headers
 
+using DocStringExtensionsMock
 import HTTP
 import Genie
 
 """
-    set_headers!(req::HTTP.Request, res::HTTP.Response, app_response::HTTP.Response) :: HTTP.Response
+$TYPEDSIGNATURES
 
 Configures the response headers.
 """
@@ -44,7 +45,7 @@ end
 
 
 """
-    normalize_headers(req::HTTP.Request)
+$TYPEDSIGNATURES
 
 Makes request headers case insensitive.
 """
@@ -63,7 +64,7 @@ end
 
 
 """
-    normalize_header_key(key::String) :: String
+$TYPEDSIGNATURES
 
 Brings header keys to standard casing.
 """

--- a/src/Input.jl
+++ b/src/Input.jl
@@ -2,6 +2,7 @@
 Handles input coming through Http server requests.
 """
 module Input
+using DocStringExtensionsMock
 
 import HttpCommon, HTTP
 
@@ -39,6 +40,9 @@ HttpFormPart() = HttpFormPart(Dict{String,Dict{String,String}}(), UInt8[])
 
 ###
 
+"""
+$TYPEDSIGNATURES
+"""
 function all(request::HTTP.Request) :: HttpInput
   input::HttpInput = HttpInput()
   post_from_request!(request, input)
@@ -46,12 +50,18 @@ function all(request::HTTP.Request) :: HttpInput
   input
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function post(request::HTTP.Request)
   input::HttpInput = all(request)
 
   input.post
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function files(request::HTTP.Request)
   input::HttpInput = all(request)
 
@@ -60,6 +70,9 @@ end
 
 ###
 
+"""
+$TYPEDSIGNATURES
+"""
 function post_from_request!(request::HTTP.Request, input::HttpInput)
   headers = Dict(request.headers)
 
@@ -72,6 +85,9 @@ function post_from_request!(request::HTTP.Request, input::HttpInput)
   nothing
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function post_url_encoded!(http_data::Array{UInt8, 1}, post_data::HttpPostData)
   params::Dict{String,String} = HTTP.URIs.queryparams(String(http_data))
 
@@ -80,6 +96,9 @@ function post_url_encoded!(http_data::Array{UInt8, 1}, post_data::HttpPostData)
   end
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function post_multipart!(request::HTTP.Request, post_data::HttpPostData, files::HttpFiles) :: Nothing
   headers = Dict(request.headers)
   boundary::String = headers["Content-Type"][(findfirst("boundary=", headers["Content-Type"])[end] + 1):end]
@@ -137,6 +156,9 @@ end
 
 ###
 
+"""
+$TYPEDSIGNATURES
+"""
 function get_multiform_parts!(http_data::Vector{UInt8}, formParts::Array{HttpFormPart}, boundary, boundaryLength::Int = length(boundary))
   ### Go through each byte of data, parsing it into POST data and files.
 
@@ -280,6 +302,9 @@ end
 
 ###
 
+"""
+$TYPEDSIGNATURES
+"""
 function parse_semicolon_fields(dataString::String)
   dataString = dataString * ";"
 
@@ -344,6 +369,9 @@ function parse_semicolon_fields(dataString::String)
   return data
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function parse_quoted_params(data::String)
   tokens = split(data, "="; limit=2)
 

--- a/src/Plugins.jl
+++ b/src/Plugins.jl
@@ -2,6 +2,7 @@
 Functionality for creating and working with Genie plugins.
 """
 module Plugins
+using DocStringExtensionsMock
 
 import Genie
 import Pkg, Markdown, Logging
@@ -20,7 +21,7 @@ const FOLDERS = [ joinpath(path_prefix, APP_FOLDER),
 
 
 """
-    recursive_copy(path::String, dest::String; only_hidden = true, force = false)
+$TYPEDSIGNATURES
 
 Utility function to copy plugin files from package dir to app.
 """
@@ -49,7 +50,7 @@ end
 
 
 """
-    congrats()
+$TYPEDSIGNATURES
 
 Shows success message and instructions when scaffolding a plugin.
 """
@@ -80,7 +81,7 @@ end
 
 
 """
-    scaffold(plugin_name::String, dest::String = "."; force = false)
+$TYPEDSIGNATURES
 
 Scaffolds a new plugin as a Julia project
 """
@@ -120,7 +121,7 @@ end
 
 
 """
-    install(path::String, dest::String; force = false)
+$TYPEDSIGNATURES
 
 Utility to allow users to install a plugin
 """

--- a/src/Renderer.jl
+++ b/src/Renderer.jl
@@ -1,4 +1,5 @@
 module Renderer
+using DocStringExtensionsMock
 
 export respond, redirect, render
 
@@ -127,7 +128,7 @@ WebRenderable(; body::String = "", content_type::Symbol = DEFAULT_CONTENT_TYPE,
 
 
 """
-    WebRenderable(wr::WebRenderable, status::Int, headers::HTTPHeaders)
+$TYPEDSIGNATURES
 
 Returns `wr` overwriting its `status` and `headers` fields with the passed arguments.
 
@@ -145,6 +146,9 @@ function WebRenderable(wr::WebRenderable, status::Int, headers::HTTPHeaders)
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function WebRenderable(wr::WebRenderable, content_type::Symbol, status::Int, headers::HTTPHeaders)
   wr.content_type = content_type
   wr.status = status
@@ -154,6 +158,9 @@ function WebRenderable(wr::WebRenderable, content_type::Symbol, status::Int, hea
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function WebRenderable(f::Function, args...)
   fr::String = try
     f() |> join
@@ -170,7 +177,7 @@ end
 
 
 """
-    render
+$TYPEDSIGNATURES
 
 Abstract function that needs to be specialized by individual renderers.
 """
@@ -180,19 +187,24 @@ function render end
 ### REDIRECT RESPONSES ###
 
 """
-Sets redirect headers and prepares the `Response`.
+$TYPEDSIGNATURES
+
+Sets redirect headers and prepares the `Response`
 """
 function redirect(location::String, code::Int = 302, headers::HTTPHeaders = HTTPHeaders()) :: HTTP.Response
   headers["Location"] = location
   WebRenderable("Redirecting you to $location", :text, code, headers) |> respond
 end
+"""
+$TYPEDSIGNATURES
+"""
 function redirect(named_route::Symbol, code::Int = 302, headers::HTTPHeaders = HTTPHeaders(); route_args...) :: HTTP.Response
   redirect(Genie.Router.linkto(named_route; route_args...), code, headers)
 end
 
 
 """
-    hasrequested(content_type::Symbol) :: Bool
+$TYPEDSIGNATURES
 
 Checks wheter or not the requested content type matches `content_type`.
 """
@@ -205,6 +217,8 @@ end
 
 
 """
+$TYPEDSIGNATURES
+
 Constructs a `Response` corresponding to the Content-Type of the request.
 """
 function respond(r::WebRenderable) :: HTTP.Response
@@ -214,11 +228,17 @@ function respond(r::WebRenderable) :: HTTP.Response
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function respond(response::HTTP.Response) :: HTTP.Response
   response
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function respond(body::String, params::Dict{Symbol,T})::HTTP.Response where {T}
   r = params[:RESPONSE]
   r.data = body
@@ -227,11 +247,17 @@ function respond(body::String, params::Dict{Symbol,T})::HTTP.Response where {T}
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function respond(err::T, content_type::Union{Symbol,String} = Genie.Router.responsetype(), code::Int = 500) :: T where {T<:Exception}
   T
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function respond(body::String, content_type::Union{Symbol,String} = Genie.Router.responsetype(), code::Int = 200) :: HTTP.Response
   HTTP.Response(code,
                 (isa(content_type, Symbol) ? ["Content-Type" => CONTENT_TYPES[content_type]] : ["Content-Type" => content_type]),
@@ -239,18 +265,24 @@ function respond(body::String, content_type::Union{Symbol,String} = Genie.Router
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function respond(body, code::Int = 200, headers::HTTPHeaders = HTTPHeaders())
   HTTP.Response(code, [h for h in headers], body = string(body))
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function respond(f::Function, code::Int = 200, headers::HTTPHeaders = HTTPHeaders())
   respond(f(), code, headers)
 end
 
 
 """
-    registervars(vs...) :: Nothing
+$TYPEDSIGNATURES
 
 Loads the rendering vars into the task's scope
 """
@@ -262,7 +294,7 @@ end
 
 
 """
-    injectkwvars() :: String
+$TYPEDSIGNATURES
 
 Sets up variables passed into the view, making them available in the
 generated view function as kw arguments for the rendering function.
@@ -279,7 +311,7 @@ end
 
 
 """
-    view_file_info(path::String, supported_extensions::Vector{String}) :: Tuple{String,String}
+$TYPEDSIGNATURES
 
 Extracts path and extension info about a file
 """
@@ -310,7 +342,7 @@ end
 
 
 """
-    vars_signature() :: String
+$TYPEDSIGNATURES
 
 Collects the names of the view vars in order to create a unique hash/salt to identify
 compiled views with different vars.
@@ -321,7 +353,7 @@ end
 
 
 """
-    function_name(file_path::String)
+$TYPEDSIGNATURES
 
 Generates function name for generated HTML+Julia views.
 """
@@ -331,7 +363,7 @@ end
 
 
 """
-    m_name(file_path::String)
+$TYPEDSIGNATURES
 
 Generates module name for generated HTML+Julia views.
 """
@@ -341,7 +373,7 @@ end
 
 
 """
-    build_is_stale(file_path::String, build_path::String) :: Bool
+$TYPEDSIGNATURES
 
 Checks if the view template has been changed since the last time the template was compiled.
 """
@@ -357,7 +389,7 @@ end
 
 
 """
-    build_module(content::String, path::String, mod_name::String) :: String
+$TYPEDSIGNATURES
 
 Persists compiled Julia view data to file and returns the path
 """
@@ -383,7 +415,7 @@ end
 
 
 """
-    preparebuilds() :: Bool
+$TYPEDSIGNATURES
 
 Sets up the build folder and the build module file for generating the compiled views.
 """
@@ -396,7 +428,7 @@ end
 
 
 """
-    purgebuilds(subfolder = BUILD_NAME) :: Bool
+$TYPEDSIGNATURES
 
 Removes the views builds folders with all the generated views.
 """
@@ -408,7 +440,7 @@ end
 
 
 """
-    changebuilds(subfolder = BUILD_NAME) :: Bool
+$TYPEDSIGNATURES
 
 Changes/creates a new builds folder.
 """
@@ -419,7 +451,7 @@ end
 
 
 """
-    function vars
+$TYPEDSIGNATURES
 
 Utility for accessing view vars
 """
@@ -429,7 +461,7 @@ end
 
 
 """
-    function vars(key)
+$TYPEDSIGNATURES
 
 Utility for accessing view vars stored under `key`
 """
@@ -439,7 +471,7 @@ end
 
 
 """
-    function vars(key, value)
+$TYPEDSIGNATURES
 
 Utility for setting a new view var, as `key` => `value`
 """
@@ -453,7 +485,7 @@ end
 
 
 """
-    set_negotiated_content(req::HTTP.Request, res::HTTP.Response, params::Dict{Symbol,Any})
+$TYPEDSIGNATURES
 
 Configures the request, response, and params response content type based on the request and defaults.
 """
@@ -469,7 +501,7 @@ end
 
 
 """
-    negotiate_content(req::Request, res::Response, params::Params) :: Response
+$TYPEDSIGNATURES
 
 Computes the content-type of the `Response`, based on the information in the `Request`.
 """

--- a/src/Requests.jl
+++ b/src/Requests.jl
@@ -2,6 +2,7 @@
 Collection of utilities for working with Requests data
 """
 module Requests
+using DocStringExtensionsMock
 
 import Genie, Genie.Router, Genie.Input
 import HTTP, Reexport
@@ -12,7 +13,7 @@ export infilespayload, filename, payload, peer
 
 
 """
-    jsonpayload()
+$TYPEDSIGNATURES
 
 Processes an `application/json` `POST` request.
 If it fails to successfully parse the `JSON` data it returns `nothing`. The original payload can still be accessed invoking `rawpayload()`
@@ -23,7 +24,7 @@ end
 
 
 """
-    jsonpayload(v)
+$TYPEDSIGNATURES
 
 Processes an `application/json` `POST` request attempting to return value corresponding to key v.
 """
@@ -33,7 +34,7 @@ end
 
 
 """
-    rawpayload() :: String
+$TYPEDSIGNATURES
 
 Returns the raw `POST` payload as a `String`.
 """
@@ -43,7 +44,7 @@ end
 
 
 """
-    filespayload() :: Dict{String,HttpFile}
+$TYPEDSIGNATURES
 
 Collection of form uploaded files.
 """
@@ -53,7 +54,7 @@ end
 
 
 """
-    filespayload(filename::Union{String,Symbol}) :: HttpFile
+$TYPEDSIGNATURES
 
 Returns the `HttpFile` uploaded through the `key` input name.
 """
@@ -63,7 +64,7 @@ end
 
 
 """
-    infilespayload(key::Union{String,Symbol}) :: Bool
+$TYPEDSIGNATURES
 
 Checks if the collection of uploaded files contains a file stored under the `key` name.
 """
@@ -73,7 +74,7 @@ end
 
 
 """
-    Base.write(filename::String = file.name; file::Input.HttpFile) :: IntBase.write(file::HttpFile, filename::String = file.name)
+$TYPEDSIGNATURES
 
 Writes uploaded `HttpFile` `file` to local storage under the `name` filename.
 Returns number of bytes written.
@@ -84,7 +85,7 @@ end
 
 
 """
-    read(file::HttpFile)
+$TYPEDSIGNATURES
 
 Returns the content of `file` as string.
 """
@@ -94,7 +95,7 @@ end
 
 
 """
-    filename(file::HttpFile) :: String
+$TYPEDSIGNATURES
 
 Original filename of the uploaded `HttpFile` `file`.
 """
@@ -104,7 +105,7 @@ end
 
 
 """
-    postpayload() :: Dict{Symbol,Any}
+$TYPEDSIGNATURES
 
 A dict representing the POST variables payload of the request (corresponding to a `form-data` request)
 """
@@ -114,7 +115,7 @@ end
 
 
 """
-    postpayload(key::Symbol) :: Any
+$TYPEDSIGNATURES
 
 Returns the value of the POST variables `key`.
 """
@@ -124,7 +125,7 @@ end
 
 
 """
-    postpayload(key::Symbol, default::Any)
+$TYPEDSIGNATURES
 
 Returns the value of the POST variables `key` or the `default` value if `key` is not defined.
 """
@@ -134,7 +135,7 @@ end
 
 
 """
-    getpayload() :: Dict{Symbol,Any}
+$TYPEDSIGNATURES
 
 A dict representing the GET/query variables payload of the request (the part correspoding to `?foo=bar&baz=moo`)
 """
@@ -144,7 +145,7 @@ end
 
 
 """
-    getpayload(key::Symbol) :: Any
+$TYPEDSIGNATURES
 
 The value of the GET/query variable `key`, as in `?key=value`
 """
@@ -154,7 +155,7 @@ end
 
 
 """
-    getpayload(key::Symbol, default::Any) :: Any
+$TYPEDSIGNATURES
 
 The value of the GET/query variable `key`, as in `?key=value`. If `key` is not defined, `default` is returned.
 """
@@ -164,7 +165,7 @@ end
 
 
 """
-    request() :: HTTP.Request
+$TYPEDSIGNATURES
 
 Returns the raw HTTP.Request object associated with the request.
 """
@@ -175,7 +176,7 @@ end
 const getrequest = request
 
 """
-    payload() :: Any
+$TYPEDSIGNATURES
 
 Utility function for accessing the `params` collection, which holds the request variables.
 """
@@ -185,7 +186,7 @@ end
 
 
 """
-    payload(key::Symbol) :: Any
+$TYPEDSIGNATURES
 
 Utility function for accessing the `key` value within the `params` collection of request variables.
 """
@@ -195,7 +196,7 @@ end
 
 
 """
-    payload(key::Symbol, default_value::T) :: Any
+$TYPEDSIGNATURES
 
 Utility function for accessing the `key` value within the `params` collection of request variables.
 If `key` is not defined, `default_value` is returned.
@@ -206,7 +207,7 @@ end
 
 
 """
-    matchedroute() :: Route
+$TYPEDSIGNATURES
 
 Returns the `Route` object which was matched for the current request.
 """
@@ -216,7 +217,7 @@ end
 
 
 """
-    matchedchannel() :: Channel
+$TYPEDSIGNATURES
 
 Returns the `Channel` object which was matched for the current request.
 """
@@ -226,7 +227,7 @@ end
 
 
 """
-    wsclient() :: HTTP.WebSockets.WebSocket
+$TYPEDSIGNATURES
 
 The web sockets client for the current request.
 """
@@ -236,7 +237,7 @@ end
 
 
 """
-    wtclient() :: HTTP.WebSockets.WebSocket
+$TYPEDSIGNATURES
 
 The web sockets client for the current request.
 """
@@ -245,16 +246,22 @@ function wtclient() :: UInt
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function getheaders(req::HTTP.Request) :: Dict{String,String}
   Dict{String,String}(req.headers)
 end
+"""
+$TYPEDSIGNATURES
+"""
 function getheaders() :: Dict{String,String}
   getheaders(getrequest())
 end
 
 
 """
-    peer()
+$TYPEDSIGNATURES
 
 Returns information about the requesting client's IP address as a NamedTuple{(:ip,), Tuple{String}}
 If the client IP address can not be retrieved, the `ip` field will return an empty string `""`.
@@ -276,7 +283,7 @@ end
 
 
 """
-    isajax(req::HTTP.Request = getrequest()) :: Bool
+$TYPEDSIGNATURES
 
 Attempts to determine if a request is Ajax by sniffing the headers.
 """

--- a/src/Responses.jl
+++ b/src/Responses.jl
@@ -2,6 +2,7 @@
 Collection of utilities for working with Responses data
 """
 module Responses
+using DocStringExtensionsMock
 
 import Genie, Genie.Router
 import HTTP
@@ -9,66 +10,111 @@ import HTTP
 export getresponse, getheaders, setheaders, setheaders!, getstatus, setstatus, setstatus!, getbody, setbody, setbody!
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function getresponse() :: HTTP.Response
   Router.params(Genie.PARAMS_RESPONSE_KEY)
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function getheaders(res::HTTP.Response) :: Dict{String,String}
   Dict{String,String}(res.headers)
 end
+"""
+$TYPEDSIGNATURES
+"""
 function getheaders() :: Dict{String,String}
   getheaders(getresponse())
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function setheaders!(res::HTTP.Response, headers::Dict) :: HTTP.Response
   push!(res.headers, [headers...]...)
 
   res
 end
+"""
+$TYPEDSIGNATURES
+"""
 function setheaders(headers::Dict) :: HTTP.Response
   setheaders!(getresponse(), headers)
 end
+"""
+$TYPEDSIGNATURES
+"""
 function setheaders(header::Pair{String,String}) :: HTTP.Response
   setheaders(Dict(header))
 end
+"""
+$TYPEDSIGNATURES
+"""
 function setheaders(headers::Vector{Pair{String,String}}) :: HTTP.Response
   setheaders(Dict(headers...))
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function getstatus(res::HTTP.Response) :: Int
   res.status
 end
+"""
+$TYPEDSIGNATURES
+"""
 function getstatus() :: Int
   getstatus(getresponse())
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function setstatus!(res::HTTP.Response, status::Int) :: HTTP.Response
   res.status = status
 
   res
 end
+"""
+$TYPEDSIGNATURES
+"""
 function setstatus(status::Int) :: HTTP.Response
   setstatus!(getresponse(), status)
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function getbody(res::HTTP.Response) :: String
   String(res.body)
 end
+"""
+$TYPEDSIGNATURES
+"""
 function getbody() :: String
   getbody(getresponse())
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function setbody!(res::HTTP.Response, body::String) :: HTTP.Response
   res.body = collect(body)
 
   res
 end
+"""
+$TYPEDSIGNATURES
+"""
 function setbody(body::String) :: HTTP.Response
   setbody!(getresponse(), body)
 end

--- a/src/Router.jl
+++ b/src/Router.jl
@@ -3,6 +3,7 @@ Parses requests and extracts parameters, setting up the call variables and invok
 the appropiate route handler function.
 """
 module Router
+using DocStringExtensionsMock
 
 import Revise
 import Reexport, Logging
@@ -78,9 +79,15 @@ mutable struct Channel
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function Base.show(io::IO, r::Route)
   print(io, "[$(r.method)] $(r.path) => $(r.action) | :$(r.name)")
 end
+"""
+$TYPEDSIGNATURES
+"""
 function Base.show(io::IO, c::Channel)
   print(io, "[WS] $(c.path) => $(c.action) | :$(c.name)")
 end
@@ -107,7 +114,7 @@ Base.getindex(params::Pair, keys...) = getindex(Dict(params), keys...)
 
 
 """
-    ispayload(req::HTTP.Request)
+$TYPEDSIGNATURES
 
 True if the request can carry a payload - that is, it's a `POST`, `PUT`, or `PATCH` request
 """
@@ -115,7 +122,7 @@ ispayload(req::HTTP.Request) = req.method in [POST, PUT, PATCH]
 
 
 """
-    ispayload()
+$TYPEDSIGNATURES
 
 True if the request can carry a payload - that is, it's a `POST`, `PUT`, or `PATCH` request
 """
@@ -123,7 +130,7 @@ ispayload() = params()[:REQUEST].method in [POST, PUT, PATCH]
 
 
 """
-    route_request(req::Request, res::Response) :: Response
+$TYPEDSIGNATURES
 
 First step in handling a request: sets up params collection, handles query vars, negotiates content.
 """
@@ -171,7 +178,7 @@ end
 
 
 """
-    route_ws_request(req::Request, msg::String, ws_client::HTTP.WebSockets.WebSocket) :: String
+$TYPEDSIGNATURES
 
 First step in handling a web socket request: sets up params collection, handles query vars.
 """
@@ -188,17 +195,25 @@ function route_ws_request(req, msg::String, ws_client) :: String
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function Base.push!(collection, name::Symbol, item::Union{Route,Channel})
   collection[name] = item
 end
 
 
 """
+$TYPEDSIGNATURES
+
 Named Genie routes constructors.
 """
 function route(action::Function, path::String; method = GET, named::Union{Symbol,Nothing} = nothing, context::Module = @__MODULE__) :: Route
   route(path, action, method = method, named = named, context = context)
 end
+"""
+$TYPEDSIGNATURES
+"""
 function route(path::String, action::Function; method = GET, named::Union{Symbol,Nothing} = nothing, context::Module = @__MODULE__) :: Route
   r = Route(method = method, path = path, action = action, name = named, context = context)
 
@@ -211,11 +226,17 @@ end
 
 
 """
+$TYPEDSIGNATURES
+
 Named Genie channels constructors.
 """
 function channel(action::Function, path::String; named::Union{Symbol,Nothing} = nothing) :: Channel
   channel(path, action, named = named)
 end
+
+"""
+$TYPEDSIGNATURES
+"""
 function channel(path::String, action::Function; named::Union{Symbol,Nothing} = nothing) :: Channel
   c = Channel(path = path, action = action, name = named)
 
@@ -228,7 +249,7 @@ end
 
 
 """
-    routename(params) :: Symbol
+$TYPEDSIGNATURES
 
 Computes the name of a route.
 """
@@ -238,7 +259,7 @@ end
 
 
 """
-    channelname(params) :: Symbol
+$TYPEDSIGNATURES
 
 Computes the name of a channel.
 """
@@ -248,7 +269,7 @@ end
 
 
 """
-    baptizer(params::Union{Route,Channel}, parts::Vector{String}) :: Symbol
+$TYPEDSIGNATURES
 
 Generates default names for routes and channels.
 """
@@ -263,6 +284,8 @@ end
 
 
 """
+$TYPEDSIGNATURES
+
 The list of the defined named routes.
 """
 function named_routes() :: OrderedCollections.OrderedDict{Symbol,Route}
@@ -272,7 +295,7 @@ const namedroutes = named_routes
 
 
 """
-    named_channels() :: Dict{Symbol,Any}
+$TYPEDSIGNATURES
 
 The list of the defined named channels.
 """
@@ -283,6 +306,8 @@ const namedchannels = named_channels
 
 
 """
+$TYPEDSIGNATURES
+
 Gets the `Route` correspoding to `routename`
 """
 function get_route(route_name::Symbol; default::Union{Route,Nothing} = Route()) :: Route
@@ -298,7 +323,7 @@ end
 
 
 """
-    routes() :: Vector{Route}
+$TYPEDSIGNATURES
 
 Returns a vector of defined routes.
 """
@@ -308,7 +333,7 @@ end
 
 
 """
-    channels() :: Vector{Channel}
+$TYPEDSIGNATURES
 
 Returns a vector of defined channels.
 """
@@ -318,7 +343,7 @@ end
 
 
 """
-    delete!(routes, route_name::Symbol)
+$TYPEDSIGNATURES
 
 Removes the route with the corresponding name from the routes collection and returns the collection of remaining routes.
 """
@@ -328,6 +353,8 @@ end
 
 
 """
+$TYPEDSIGNATURES
+
 Generates the HTTP link corresponding to `route_name` using the parameters in `d`.
 """
 function to_link(route_name::Symbol, d::Dict{Symbol,T}; preserve_query::Bool = true, extra_query::Dict = Dict())::String where {T}
@@ -380,6 +407,8 @@ end
 
 
 """
+$TYPEDSIGNATURES
+
 Generates the HTTP link corresponding to `route_name` using the parameters in `route_params`.
 """
 function to_link(route_name::Symbol; preserve_query::Bool = true, extra_query::Dict = Dict(), route_params...) :: String
@@ -393,7 +422,7 @@ const toroute = to_link
 
 
 """
-    route_params_to_dict(route_params)
+$TYPEDSIGNATURES
 
 Converts the route params to a `Dict`.
 """
@@ -403,7 +432,7 @@ end
 
 
 """
-    action_controller_params(action::Function, params::Params) :: Nothing
+$TYPEDSIGNATURES
 
 Sets up the :action_controller, :action, and :controller key - value pairs of the `params` collection.
 """
@@ -419,7 +448,7 @@ end
 
 
 """
-    match_routes(req::Request, res::Response, params::Params) :: Response
+$TYPEDSIGNATURES
 
 Matches the invoked URL to the corresponding route, sets up the execution environment and invokes the controller method.
 """
@@ -482,29 +511,44 @@ function match_routes(req::HTTP.Request, res::HTTP.Response, params::Params) :: 
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function handle_exception(ex::Genie.Exceptions.ExceptionalResponse)
   ex.response
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function handle_exception(ex::Genie.Exceptions.RuntimeException)
   rethrow(ex)
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function handle_exception(ex::Genie.Exceptions.InternalServerException)
   error(ex.message, response_mime(), Val(500))
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function handle_exception(ex::Genie.Exceptions.NotFoundException)
   error(ex.resource, response_mime(), Val(404))
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function handle_exception(ex::Exception)
   rethrow(ex)
 end
 
 
 """
-    match_channels(req::Request, msg::String, ws_client::HTTP.WebSockets.WebSocket, params::Params) :: String
+$TYPEDSIGNATURES
 
 Matches the invoked URL to the corresponding channel, sets up the execution environment and invokes the channel controller method.
 """
@@ -560,7 +604,7 @@ end
 
 
 """
-    parse_route(route::String, context::Module = @__MODULE__) :: Tuple{String,Vector{String},Vector{Any}}
+$TYPEDSIGNATURES
 
 Parses a route and extracts its named params and types. `context` is used to access optional route parts types.
 """
@@ -606,7 +650,7 @@ end
 
 
 """
-    parse_channel(channel::String) :: Tuple{String,Vector{String},Vector{Any}}
+$TYPEDSIGNATURES
 
 Parses a channel and extracts its named parms and types.
 """
@@ -643,7 +687,7 @@ parse_param(param_type::Type{<:Number}, param::AbstractString) = parse(param_typ
 parse_param(param_type::Type{T}, param::S) where {T, S} = convert(param_type, param)
 
 """
-    extract_uri_params(uri::String, regex_route::Regex, param_names::Vector{String}, param_types::Vector{Any}, params::Params) :: Bool
+$TYPEDSIGNATURES
 
 Extracts params from request URI and sets up the `params` `Dict`.
 """
@@ -666,7 +710,7 @@ end
 
 
 """
-    extract_get_params(uri::URI, params::Params) :: Bool
+$TYPEDSIGNATURES
 
 Extracts query vars and adds them to the execution `params` `Dict`.
 """
@@ -703,7 +747,7 @@ end
 
 
 """
-    extract_post_params(req::Request, params::Params) :: Nothing
+$TYPEDSIGNATURES
 
 Parses POST variables and adds the to the `params` `Dict`.
 """
@@ -730,7 +774,7 @@ end
 
 
 """
-    extract_request_params(req::HTTP.Request, params::Params) :: Nothing
+$TYPEDSIGNATURES
 
 Sets up the `params` key-value pairs corresponding to a JSON payload.
 """
@@ -759,6 +803,9 @@ function extract_request_params(req::HTTP.Request, params::Params) :: Nothing
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function Dict(o::JSON3.Object) :: Dict{String,Any}
   r = Dict{String,Any}()
 
@@ -771,7 +818,7 @@ end
 
 
 """
-    content_type(req::HTTP.Request) :: String
+$TYPEDSIGNATURES
 
 Gets the content-type of the request.
 """
@@ -781,20 +828,23 @@ end
 
 
 """
-    content_length(req::HTTP.Request) :: Int
+$TYPEDSIGNATURES
 
 Gets the content-length of the request.
 """
 function content_length(req::HTTP.Request) :: Int
   parse(Int, get(Genie.HTTPUtils.Dict(req), "content-length", "0"))
 end
+"""
+$TYPEDSIGNATURES
+"""
 function content_length() :: Int
   content_length(params(Genie.PARAMS_REQUEST_KEY))
 end
 
 
 """
-    request_type_is(req::HTTP.Request, request_type::Symbol) :: Bool
+$TYPEDSIGNATURES
 
 Checks if the request content-type is of a certain type.
 """
@@ -805,13 +855,16 @@ function request_type_is(req::HTTP.Request, request_type::Symbol) :: Bool
 
   false
 end
+"""
+$TYPEDSIGNATURES
+"""
 function request_type_is(request_type::Symbol) :: Bool
   request_type_is(params(Genie.PARAMS_REQUEST_KEY), request_type)
 end
 
 
 """
-    request_type(req::HTTP.Request) :: Symbol
+$TYPEDSIGNATURES
 
 Gets the request's content type.
 """
@@ -831,7 +884,7 @@ end
 
 
 """
-    nested_keys(k::String, v, params::Params) :: Nothing
+$TYPEDSIGNATURES
 
 Utility function to process nested keys and set them up in `params`.
 """
@@ -853,7 +906,7 @@ end
 
 
 """
-    setup_base_params(req::Request, res::Response, params::Dict{Symbol,Any}) :: Dict{Symbol,Any}
+$TYPEDSIGNATURES
 
 Populates `params` with default environment vars.
 """
@@ -871,11 +924,11 @@ end
 
 
 """
-    to_response(action_result) :: Response
+$TYPEDSIGNATURES
 
 Converts the result of invoking the controller action to a `Response`.
-"""
-to_response(action_result::HTTP.Response)::HTTP.Response = action_result
+"""    
+to_response(action_result::HTTP.Response)::HTTP.Response = action_result    
 to_response(action_result::Tuple)::HTTP.Response = HTTP.Response(action_result...)
 to_response(action_result::Vector)::HTTP.Response = HTTP.Response(join(action_result))
 to_response(action_result::Nothing)::HTTP.Response = HTTP.Response("")
@@ -884,9 +937,8 @@ to_response(action_result::Genie.Exceptions.ExceptionalResponse)::HTTP.Response 
 to_response(action_result::Exception)::HTTP.Response = throw(action_result)
 to_response(action_result::Any)::HTTP.Response = HTTP.Response(string(action_result))
 
-
 """
-    function params()
+$TYPEDSIGNATURES
 
 The collection containing the request variables collection.
 """
@@ -903,9 +955,8 @@ function params!(key, value)
   task_local_storage(:__params)[key] = value
 end
 
-
 """
-    function query
+$TYPEDSIGNATURES
 
 The collection containing the query request variables collection (GET params).
 """
@@ -921,7 +972,7 @@ end
 
 
 """
-    function post
+$TYPEDSIGNATURES
 
 The collection containing the POST request variables collection.
 """
@@ -935,9 +986,8 @@ function post(key, default)
   get(post(), key, default)
 end
 
-
 """
-    function request()
+$TYPEDSIGNATURES
 
 The request object.
 """
@@ -945,9 +995,8 @@ function request()
   params(Genie.PARAMS_REQUEST_KEY)
 end
 
-
 """
-    function headers()
+$TYPEDSIGNATURES
 
 The current request's headers (as a Dict)
 """
@@ -957,24 +1006,29 @@ end
 
 
 """
-    response_type{T}(params::Dict{Symbol,T}) :: Symbol
-    response_type(params::Params) :: Symbol
+$TYPEDSIGNATURES
 
 Returns the content-type of the current request-response cycle.
 """
 function response_type(params::Dict{Symbol,T})::Symbol where {T}
   get(params, :response_type, request_type(params[Genie.PARAMS_REQUEST_KEY]))
 end
+"""
+$TYPEDSIGNATURES
+"""
 function response_type(params::Params) :: Symbol
   response_type(params.collection)
 end
+"""
+$TYPEDSIGNATURES
+"""
 function response_type() :: Symbol
   response_type(params())
 end
 
 
 """
-    response_type{T}(check::Symbol, params::Dict{Symbol,T}) :: Bool
+$TYPEDSIGNATURES
 
 Checks if the content-type of the current request-response cycle matches `check`.
 """
@@ -987,7 +1041,7 @@ const responsetype = response_type
 
 
 """
-    append_to_routes_file(content::String) :: Nothing
+$TYPEDSIGNATURES
 
 Appends `content` to the app's route file.
 """
@@ -1001,7 +1055,7 @@ end
 
 
 """
-    is_static_file(resource::String) :: Bool
+$TYPEDSIGNATURES
 
 Checks if the requested resource is a static file.
 """
@@ -1011,7 +1065,7 @@ end
 
 
 """
-    escape_resource_path(resource::String)
+$TYPEDSIGNATURES
 
 Cleans up paths to resources.
 """
@@ -1024,7 +1078,7 @@ end
 
 
 """
-    serve_static_file(resource::String) :: Response
+$TYPEDSIGNATURES
 
 Reads the static file and returns the content as a `Response`.
 """
@@ -1055,7 +1109,7 @@ end
 
 
 """
-preflight_response() :: HTTP.Response
+$TYPEDSIGNATURES
 
 Sets up the preflight CORS response header.
 """
@@ -1065,7 +1119,7 @@ end
 
 
 """
-    response_mime()
+$TYPEDSIGNATURES
 
 Returns the MIME type of the response.
 """
@@ -1081,13 +1135,16 @@ end
 
 
 """
-    error
+$TYPEDSIGNATURES
 
 Not implemented function for error response.
 """
 function error end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function trymime(mime::Any)
   try
     mime()
@@ -1097,23 +1154,32 @@ function trymime(mime::Any)
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function error(error_message::String, mime::Any, ::Val{500}; error_info::String = "") :: HTTP.Response
   HTTP.Response(500, ["Content-Type" => string(trymime(mime))], body = "500 Internal Error - $error_message. $error_info")
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function error(error_message::String, mime::Any, ::Val{404}; error_info::String = "") :: HTTP.Response
   HTTP.Response(404, ["Content-Type" => string(trymime(mime))], body = "404 Not Found - $error_message. $error_info")
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function error(error_code::Int, error_message::String, mime::Any; error_info::String = "") :: HTTP.Response
   HTTP.Response(error_code, ["Content-Type" => string(trymime(mime))], body = "$error_code Error - $error_message. $error_info")
 end
 
 
 """
-    file_path(resource::String; within_doc_root = true) :: String
+$TYPEDSIGNATURES
 
 Returns the path to a resource file. If `within_doc_root` it will automatically prepend the document root to `resource`.
 """
@@ -1141,7 +1207,7 @@ file_extension(f) :: String = ormatch(match(r"(?<=\.)[^\.\\/]*$", f), "")
 
 
 """
-    file_headers(f) :: Dict{String,String}
+$TYPEDSIGNATURES
 
 Returns the file headers of `f`.
 """

--- a/src/Sessions.jl
+++ b/src/Sessions.jl
@@ -1,4 +1,5 @@
 module Sessions
+using DocStringExtensionsMock
 
 import SHA, HTTP, Dates, Logging
 import Genie
@@ -28,7 +29,7 @@ InvalidSessionIdException() =
 
 
 """
-    id() :: String
+$TYPEDSIGNATURES
 
 Generates a new session id.
 """
@@ -57,7 +58,7 @@ end
 
 
 """
-    id(payload::Union{HTTP.Request,HTTP.Response}) :: String
+$TYPEDSIGNATURES
 
 Attempts to retrieve the session id from the provided `payload` object.
 If that is not available, a new session id is created.
@@ -72,7 +73,7 @@ end
 
 
 """
-    id(req::HTTP.Request, res::HTTP.Response) :: String
+$TYPEDSIGNATURES
 
 Attempts to retrieve the session id from the provided request and response objects.
 If that is not available, a new session id is created.
@@ -89,7 +90,7 @@ end
 
 
 """
-    init() :: Nothing
+$TYPEDSIGNATURES
 
 Sets up the session functionality, if configured.
 """
@@ -105,7 +106,7 @@ end
 
 
 """
-    start(session_id::String, req::HTTP.Request, res::HTTP.Response; options = Dict{String,String}()) :: Tuple{Session,HTTP.Response}
+$TYPEDSIGNATURES
 
 Initiates a new HTTP session with the provided `session_id`.
 
@@ -124,7 +125,7 @@ end
 
 
 """
-    start(req::HTTP.Request, res::HTTP.Response; options::Dict{String,String} = Dict{String,String}()) :: Session
+$TYPEDSIGNATURES
 
 Initiates a new default session object, generating a new session id.
 
@@ -156,7 +157,7 @@ end
 
 
 """
-    set!(s::Session, key::Symbol, value::Any) :: Session
+$TYPEDSIGNATURES
 
 Stores `value` as `key` on the `Session` object `s`.
 """
@@ -168,7 +169,7 @@ end
 
 
 """
-    get(s::Session, key::Symbol) :: Union{Nothing,Any}
+$TYPEDSIGNATURES
 
 Returns the value stored on the `Session` object `s` as `key`, wrapped in a `Union{Nothing,Any}`.
 """
@@ -178,7 +179,7 @@ end
 
 
 """
-    get(s::Session, key::Symbol, default::T) :: T where T
+$TYPEDSIGNATURES
 
 Attempts to retrive the value stored on the `Session` object `s` as `key`.
 If the value is not set, it returns the `default`.
@@ -191,7 +192,7 @@ end
 
 
 """
-    unset!(s::Session, key::Symbol) :: Session
+$TYPEDSIGNATURES
 
 Removes the value stored on the `Session` `s` as `key`.
 """
@@ -203,7 +204,7 @@ end
 
 
 """
-    isset(s::Session, key::Symbol) :: Bool
+$TYPEDSIGNATURES
 
 Checks wheter or not `key` exists on the `Session` `s`.
 """
@@ -213,7 +214,7 @@ end
 
 
 """
-    persist(s::Session) :: Session
+$TYPEDSIGNATURES
 
 Generic method for persisting session data - delegates to the underlying `SessionAdapter`.
 """
@@ -221,7 +222,7 @@ function persist end
 
 
 """
-    load(session_id::String) :: Session
+$TYPEDSIGNATURES
 
 Loads session data from persistent storage - delegates to the underlying `SessionAdapter`.
 """
@@ -229,7 +230,7 @@ function load end
 
 
 """
-    session(params::Dict{Symbol,Any}) :: Sessions.Session
+$TYPEDSIGNATURES
 
 Returns the `Session` object associated with the current HTTP request.
 """

--- a/src/Toolbox.jl
+++ b/src/Toolbox.jl
@@ -1,4 +1,5 @@
 module Toolbox
+using DocStringExtensionsMock
 
 import Base.string
 
@@ -23,7 +24,7 @@ end
 
 
 """
-    tasks(; filter_type_name = Symbol()) :: Vector{TaskInfo}
+$TYPEDSIGNATURES
 
 Returns a vector of all registered Genie tasks.
 """
@@ -51,13 +52,16 @@ end
 const loadtasks = tasks
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function VoidTaskResult()
   TaskResult(0, "", nothing)
 end
 
 
 """
-    validtaskname(task_name::String) :: String
+$TYPEDSIGNATURES
 
 Attempts to convert a potentially invalid (partial) `task_name` into a valid one.
 """
@@ -71,6 +75,8 @@ end
 
 
 """
+$TYPEDSIGNATURES
+
 Prints a list of all the registered Genie tasks to the standard output.
 """
 function printtasks(context::Module) :: Nothing
@@ -86,7 +92,7 @@ end
 
 
 """
-    task_docs(module_name::Module) :: String
+$TYPEDSIGNATURES
 
 Retrieves the docstring of the runtask method and returns it as a string.
 """
@@ -104,7 +110,7 @@ end
 
 
 """
-    new(task_name::String) :: Nothing
+$TYPEDSIGNATURES
 
 Generates a new Genie task file.
 """
@@ -126,7 +132,7 @@ end
 
 
 """
-    task_file_name(cmd_args::Dict{String,Any}, config::Settings) :: String
+$TYPEDSIGNATURES
 
 Computes the name of a Genie task based on the command line input.
 """
@@ -136,7 +142,7 @@ end
 
 
 """
-    task_module_name(underscored_task_name::String) :: String
+$TYPEDSIGNATURES
 
 Computes the name of a Genie task based on the command line input.
 """
@@ -146,7 +152,7 @@ end
 
 
 """
-    isvalidtask!(parsed_args::Dict{String,Any}) :: Dict{String,Any}
+$TYPEDSIGNATURES
 
 Checks if the name of the task passed as the command line arg is valid task identifier -- if not, attempts to address it, by appending the TASK_SUFFIX suffix.
 Returns the potentially modified `parsed_args` `Dict`.

--- a/src/Util.jl
+++ b/src/Util.jl
@@ -1,4 +1,5 @@
 module Util
+using DocStringExtensionsMock
 
 import Genie
 
@@ -7,7 +8,7 @@ export expand_nullable, time_to_unixtimestamp
 
 
 """
-    expand_nullable{T}(value::Union{Nothing,T}, default::T) :: T
+$TYPEDSIGNATURES
 
 Returns `value` if it is not `nothing` - otherwise `default`.
 """
@@ -17,7 +18,7 @@ end
 
 
 """
-    file_name_without_extension(file_name, extension = ".jl") :: String
+$TYPEDSIGNATURES
 
 Removes the file extension `extension` from `file_name`.
 """
@@ -27,7 +28,7 @@ end
 
 
 """
-    function walk_dir(dir, paths = String[]; only_extensions = ["jl"], only_files = true, only_dirs = false) :: Vector{String}
+$TYPEDSIGNATURES
 
 Recursively walks dir and `produce`s non directories. If `only_files`, directories will be skipped. If `only_dirs`, files will be skipped.
 """
@@ -52,7 +53,7 @@ end
 
 
 """
-    time_to_unixtimestamp(t::Float64 = time()) :: Int
+$TYPEDSIGNATURES
 
 Converts a time value to the corresponding unix timestamp.
 """
@@ -62,7 +63,7 @@ end
 
 
 """
-    filterwhitespace(s::String, allowed::Vector{Char} = Char[]) :: String
+$TYPEDSIGNATURES
 
 Removes whitespaces from `s`, whith the exception of the characters in `allowed`.
 """

--- a/src/WebChannels.jl
+++ b/src/WebChannels.jl
@@ -2,6 +2,7 @@
 Handles WebSockets communication logic.
 """
 module WebChannels
+using DocStringExtensionsMock
 
 import HTTP, Distributed, Logging, JSON3
 import Genie, Genie.Renderer
@@ -29,6 +30,9 @@ mutable struct ChannelMessage
   payload::MessagePayload
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function JSON3.StructTypes.StructType(::Type{T}) where {T<:ChannelMessage}
   JSON3.StructTypes.Struct()
 end
@@ -43,6 +47,9 @@ websockets() = map(c -> c.client, clients())
 channels() = collect(keys(SUBSCRIPTIONS))
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function connected_clients(channel::ChannelName) :: Vector{ChannelClient}
   clients = ChannelClient[]
   for client_id in SUBSCRIPTIONS[channel]
@@ -51,6 +58,9 @@ function connected_clients(channel::ChannelName) :: Vector{ChannelClient}
 
   clients
 end
+"""
+$TYPEDSIGNATURES
+"""
 function connected_clients() :: Vector{ChannelClient}
   clients = ChannelClient[]
   for ch in channels()
@@ -61,6 +71,9 @@ function connected_clients() :: Vector{ChannelClient}
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function disconnected_clients(channel::ChannelName) :: Vector{ChannelClient}
   clients = ChannelClient[]
   for client_id in SUBSCRIPTIONS[channel]
@@ -69,6 +82,9 @@ function disconnected_clients(channel::ChannelName) :: Vector{ChannelClient}
 
   clients
 end
+"""
+$TYPEDSIGNATURES
+"""
 function disconnected_clients() :: Vector{ChannelClient}
   clients = ChannelClient[]
   for ch in channels()
@@ -80,6 +96,8 @@ end
 
 
 """
+$TYPEDSIGNATURES
+
 Subscribes a web socket client `ws` to `channel`.
 """
 function subscribe(ws::HTTP.WebSockets.WebSocket, channel::ChannelName) :: ChannelClientsCollection
@@ -95,12 +113,17 @@ function subscribe(ws::HTTP.WebSockets.WebSocket, channel::ChannelName) :: Chann
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function id(ws::HTTP.WebSockets.WebSocket) :: UInt
   hash(ws)
 end
 
 
 """
+$TYPEDSIGNATURES
+
 Unsubscribes a web socket client `ws` from `channel`.
 """
 function unsubscribe(ws::HTTP.WebSockets.WebSocket, channel::ChannelName) :: ChannelClientsCollection
@@ -109,12 +132,17 @@ function unsubscribe(ws::HTTP.WebSockets.WebSocket, channel::ChannelName) :: Cha
 
   CLIENTS
 end
+"""
+$TYPEDSIGNATURES
+"""
 function unsubscribe(channel_client::ChannelClient, channel::ChannelName) :: ChannelClientsCollection
   unsubscribe(channel_client.client, channel)
 end
 
 
 """
+$TYPEDSIGNATURES
+
 Unsubscribes a web socket client `ws` from all the channels.
 """
 function unsubscribe_client(ws::HTTP.WebSockets.WebSocket) :: ChannelClientsCollection
@@ -128,11 +156,17 @@ function unsubscribe_client(ws::HTTP.WebSockets.WebSocket) :: ChannelClientsColl
 
   CLIENTS
 end
+"""
+$TYPEDSIGNATURES
+"""
 function unsubscribe_client(client_id::ClientId) :: ChannelClientsCollection
   unsubscribe_client(CLIENTS[client_id].client)
 
   CLIENTS
 end
+"""
+$TYPEDSIGNATURES
+"""
 function unsubscribe_client(channel_client::ChannelClient) :: ChannelClientsCollection
   unsubscribe_client(channel_client.client)
 
@@ -141,7 +175,7 @@ end
 
 
 """
-unsubscribe_disconnected_clients() :: ChannelClientsCollection
+$TYPEDSIGNATURES
 
 Unsubscribes clients which are no longer connected.
 """
@@ -152,6 +186,9 @@ function unsubscribe_disconnected_clients() :: ChannelClientsCollection
 
   CLIENTS
 end
+"""
+$TYPEDSIGNATURES
+"""
 function unsubscribe_disconnected_clients(channel::ChannelName) :: ChannelClientsCollection
   for channel_client in disconnected_clients(channel)
     unsubscribe(channel_client, channel)
@@ -162,6 +199,8 @@ end
 
 
 """
+$TYPEDSIGNATURES
+
 Adds a new subscription for `client` to `channel`.
 """
 function push_subscription(client_id::ClientId, channel::ChannelName) :: ChannelSubscriptionsCollection
@@ -173,12 +212,17 @@ function push_subscription(client_id::ClientId, channel::ChannelName) :: Channel
 
   SUBSCRIPTIONS
 end
+"""
+$TYPEDSIGNATURES
+"""
 function push_subscription(channel_client::ChannelClient, channel::ChannelName) :: ChannelSubscriptionsCollection
   push_subscription(id(channel_client.client), channel)
 end
 
 
 """
+$TYPEDSIGNATURES
+
 Removes the subscription of `client` to `channel`.
 """
 function pop_subscription(client::ClientId, channel::ChannelName) :: ChannelSubscriptionsCollection
@@ -191,12 +235,17 @@ function pop_subscription(client::ClientId, channel::ChannelName) :: ChannelSubs
 
   SUBSCRIPTIONS
 end
+"""
+$TYPEDSIGNATURES
+"""
 function pop_subscription(channel_client::ChannelClient, channel::ChannelName) :: ChannelSubscriptionsCollection
   pop_subscription(id(channel_client.client), channel)
 end
 
 
 """
+$TYPEDSIGNATURES
+
 Removes all subscriptions of `client`.
 """
 function pop_subscription(channel::ChannelName) :: ChannelSubscriptionsCollection
@@ -209,6 +258,8 @@ end
 
 
 """
+$TYPEDSIGNATURES
+
 Pushes `msg` (and `payload`) to all the clients subscribed to the channels in `channels`, with the exception of `except`.
 """
 function broadcast(channels::Union{ChannelName,Vector{ChannelName}},
@@ -238,6 +289,8 @@ end
 
 
 """
+$TYPEDSIGNATURES
+
 Pushes `msg` (and `payload`) to all the clients subscribed to the channels in `channels`, with the exception of `except`.
 """
 function broadcast(msg::String;
@@ -250,6 +303,8 @@ end
 
 
 """
+$TYPEDSIGNATURES
+
 Pushes `js_code` (a JavaScript piece of code) to be executed by all the clients subscribed to the channels in `channels`,
 with the exception of `except`.
 """
@@ -260,14 +315,22 @@ end
 
 
 """
+$TYPEDSIGNATURES
+
 Writes `msg` to web socket for `client`.
 """
 function message(ws::HTTP.WebSockets.WebSocket, msg::String) :: Int
   write(ws, msg)
 end
+"""
+$TYPEDSIGNATURES
+"""
 function message(client::ClientId, msg::String) :: Int
   message(CLIENTS[client].client, msg)
 end
+"""
+$TYPEDSIGNATURES
+"""
 function message(client::ChannelClient, msg::String) :: Int
   message(client.client, msg)
 end

--- a/src/WebThreads.jl
+++ b/src/WebThreads.jl
@@ -2,6 +2,7 @@
 Handles Ajax communication logic.
 """
 module WebThreads
+using DocStringExtensionsMock
 
 import HTTP, Distributed, Logging, Dates
 import Genie, Genie.Renderer
@@ -39,6 +40,9 @@ webthreads() = map(c -> c.client, clients())
 channels() = collect(keys(SUBSCRIPTIONS))
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function connected_clients(channel::ChannelName) :: Vector{ChannelClient}
   clients = ChannelClient[]
   for client_id in SUBSCRIPTIONS[channel]
@@ -47,6 +51,9 @@ function connected_clients(channel::ChannelName) :: Vector{ChannelClient}
 
   clients
 end
+"""
+$TYPEDSIGNATURES
+"""
 function connected_clients() :: Vector{ChannelClient}
   clients = ChannelClient[]
   for ch in channels()
@@ -57,6 +64,9 @@ function connected_clients() :: Vector{ChannelClient}
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function disconnected_clients(channel::ChannelName) :: Vector{ChannelClient}
   clients = ChannelClient[]
   for client_id in SUBSCRIPTIONS[channel]
@@ -65,6 +75,9 @@ function disconnected_clients(channel::ChannelName) :: Vector{ChannelClient}
 
   clients
 end
+"""
+$TYPEDSIGNATURES
+"""
 function disconnected_clients() :: Vector{ChannelClient}
   clients = ChannelClient[]
   for ch in channels()
@@ -76,6 +89,8 @@ end
 
 
 """
+$TYPEDSIGNATURES
+
 Subscribes a web thread client `wt` to `channel`.
 """
 function subscribe(wt::UInt, channel::ChannelName) :: ChannelClientsCollection
@@ -94,6 +109,8 @@ end
 
 
 """
+$TYPEDSIGNATURES
+
 Unsubscribes a web socket client `wt` from `channel`.
 """
 function unsubscribe(wt::UInt, channel::ChannelName) :: ChannelClientsCollection
@@ -102,12 +119,17 @@ function unsubscribe(wt::UInt, channel::ChannelName) :: ChannelClientsCollection
 
   CLIENTS
 end
+"""
+$TYPEDSIGNATURES
+"""
 function unsubscribe(channel_client::ChannelClient, channel::ChannelName) :: ChannelClientsCollection
   unsubscribe(channel_client.client, channel)
 end
 
 
 """
+$TYPEDSIGNATURES
+
 Unsubscribes a web socket client `wt` from all the channels.
 """
 function unsubscribe_client(wt::UInt) :: ChannelClientsCollection
@@ -121,6 +143,9 @@ function unsubscribe_client(wt::UInt) :: ChannelClientsCollection
 
   CLIENTS
 end
+"""
+$TYPEDSIGNATURES
+"""
 function unsubscribe_client(channel_client::ChannelClient) :: ChannelClientsCollection
   unsubscribe_client(channel_client.client)
 
@@ -129,7 +154,7 @@ end
 
 
 """
-unsubscribe_disconnected_clients() :: ChannelClientsCollection
+$TYPEDSIGNATURES
 
 Unsubscribes clients which are no longer connected.
 """
@@ -140,6 +165,9 @@ function unsubscribe_disconnected_clients() :: ChannelClientsCollection
 
   CLIENTS
 end
+"""
+$TYPEDSIGNATURES
+"""
 function unsubscribe_disconnected_clients(channel::ChannelName) :: ChannelClientsCollection
   for channel_client in disconnected_clients(channel)
     unsubscribe(channel_client, channel)
@@ -149,12 +177,18 @@ function unsubscribe_disconnected_clients(channel::ChannelName) :: ChannelClient
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function unsubscribe_clients()
   empty!(CLIENTS)
   empty!(SUBSCRIPTIONS)
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function timestamp_client(client_id::ClientId) :: Nothing
   haskey(CLIENTS, client_id) && (CLIENTS[client_id].last_active = Dates.now())
 
@@ -163,6 +197,8 @@ end
 
 
 """
+$TYPEDSIGNATURES
+
 Adds a new subscription for `client` to `channel`.
 """
 function push_subscription(client_id::ClientId, channel::ChannelName) :: ChannelSubscriptionsCollection
@@ -176,12 +212,17 @@ function push_subscription(client_id::ClientId, channel::ChannelName) :: Channel
 
   SUBSCRIPTIONS
 end
+"""
+$TYPEDSIGNATURES
+"""
 function push_subscription(channel_client::ChannelClient, channel::ChannelName) :: ChannelSubscriptionsCollection
   push_subscription(channel_client.client, channel)
 end
 
 
 """
+$TYPEDSIGNATURES
+
 Removes the subscription of `client` to `channel`.
 """
 function pop_subscription(client::ClientId, channel::ChannelName) :: ChannelSubscriptionsCollection
@@ -196,12 +237,17 @@ function pop_subscription(client::ClientId, channel::ChannelName) :: ChannelSubs
 
   SUBSCRIPTIONS
 end
+"""
+$TYPEDSIGNATURES
+"""
 function pop_subscription(channel_client::ChannelClient, channel::ChannelName) :: ChannelSubscriptionsCollection
   pop_subscription(channel_client.client, channel)
 end
 
 
 """
+$TYPEDSIGNATURES
+
 Removes all subscriptions of `client`.
 """
 function pop_subscription(channel::ChannelName) :: ChannelSubscriptionsCollection
@@ -214,6 +260,8 @@ end
 
 
 """
+$TYPEDSIGNATURES
+
 Pushes `msg` (and `payload`) to all the clients subscribed to the channels in `channels`.
 """
 function broadcast(channels::Union{ChannelName,Vector{ChannelName}}, msg::String;
@@ -236,6 +284,11 @@ function broadcast(channels::Union{ChannelName,Vector{ChannelName}}, msg::String
 
   true
 end
+"""
+$TYPEDSIGNATURES
+
+Pushes `msg` (and `payload`) to all the clients subscribed to all the channels.
+"""
 function broadcast(channels::Union{ChannelName,Vector{ChannelName}}, msg::String, payload::Dict) :: Bool
   isa(channels, Array) || (channels = [channels])
 
@@ -256,6 +309,8 @@ end
 
 
 """
+$TYPEDSIGNATURES
+
 Pushes `msg` (and `payload`) to all the clients subscribed to all the channels.
 """
 function broadcast(msg::String, payload::Union{Dict,Nothing} = nothing) :: Bool
@@ -266,6 +321,8 @@ end
 
 
 """
+$TYPEDSIGNATURES
+
 Pushes `msg` (and `payload`) to `channel`.
 """
 function message(channel::ChannelName, msg::String, payload::Union{Dict,Nothing} = nothing) :: Bool
@@ -276,16 +333,24 @@ end
 
 
 """
+$TYPEDSIGNATURES
+
 Writes `msg` to message queue for `client`.
 """
 function message(wt::UInt, msg::String)
   push!(MESSAGE_QUEUE[wt], msg)
 end
+"""
+$TYPEDSIGNATURES
+"""
 function message(client::ChannelClient, msg::String)
   message(client.client, msg)
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function pull(wt::UInt, channel::ChannelName)
   output = ""
   if haskey(MESSAGE_QUEUE, wt) && ! isempty(MESSAGE_QUEUE[wt])
@@ -298,6 +363,9 @@ function pull(wt::UInt, channel::ChannelName)
   output
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function push(wt::UInt, channel::ChannelName, message::String)
   timestamp_client(wt)
 

--- a/src/cache_adapters/FileCache.jl
+++ b/src/cache_adapters/FileCache.jl
@@ -7,7 +7,7 @@ import Genie, Genie.Cache
 # IMPLEMENTATION #
 
 """
-    tocache(key::Any, content::Any; dir::String = "") :: Nothing
+$TYPEDSIGNATURES
 
 Persists `content` onto the file system under the `key` key.
 """
@@ -21,7 +21,7 @@ end
 
 
 """
-    fromcache(key::Any, expiration::Int; dir::String = "") :: Union{Nothing,Any}
+$TYPEDSIGNATURES
 
 Retrieves from cache the object stored under the `key` key if the `expiration` delta (in seconds) is in the future.
 """
@@ -42,7 +42,7 @@ end
 
 
 """
-    cache_path(key::Any; dir::String = "") :: String
+$TYPEDSIGNATURES
 
 Computes the path to a cache `key` based on current cache settings.
 """
@@ -59,7 +59,7 @@ end
 
 
 """
-    withcache(f::Function, key::Any, expiration::Int = Genie.config.cache_duration; dir = "", condition::Bool = true)
+$TYPEDSIGNATURES
 
 Executes the function `f` and stores the result into the cache for the duration (in seconds) of `expiration`. Next time the function is invoked,
 if the cache has not expired, the cached result is returned skipping the function execution.
@@ -83,7 +83,7 @@ end
 
 
 """
-    purge(key::Any) :: Nothing
+$TYPEDSIGNATURES
 
 Removes the cache data stored under the `key` key.
 """
@@ -95,7 +95,7 @@ end
 
 
 """
-    purgeall(; dir::String = "") :: Nothing
+$TYPEDSIGNATURES
 
 Removes all cached data.
 """

--- a/src/genie_module.jl
+++ b/src/genie_module.jl
@@ -9,7 +9,7 @@ import REPL, REPL.Terminals
 
 
 """
-    newcontroller(controller_name::Union{String,Symbol}) :: Nothing
+$TYPEDSIGNATURES
 
 Creates a new `controller` file. If `pluralize` is `false`, the name of the controller is not automatically pluralized.
 """
@@ -22,7 +22,7 @@ end
 
 
 """
-    newresource(resource_name::Union{String,Symbol}; pluralize::Bool = true, context::Union{Module,Nothing} = nothing) :: Nothing
+$TYPEDSIGNATURES
 
 Creates all the files associated with a new resource.
 If `pluralize` is `false`, the name of the resource is not automatically pluralized.
@@ -44,7 +44,7 @@ end
 
 
 """
-    newtask(task_name::Union{String,Symbol}) :: Nothing
+$TYPEDSIGNATURES
 
 Creates a new Genie `Task` file.
 """
@@ -61,7 +61,7 @@ end
 
 
 """
-    load_libs(root_dir::String = Genie.config.path_lib) :: Nothing
+$TYPEDSIGNATURES
 
 Recursively adds subfolders of `lib/` to LOAD_PATH.
 The `lib/` folder, if present, is designed to host user code in the form of .jl files.
@@ -84,7 +84,7 @@ end
 
 
 """
-    load_resources(root_dir::String = Genie.config.path_resources) :: Nothing
+$TYPEDSIGNATURES
 
 Recursively adds subfolders of `resources/` to LOAD_PATH.
 """
@@ -105,7 +105,7 @@ end
 
 
 """
-    load_helpers(root_dir::String = Genie.config.path_helpers) :: Nothing
+$TYPEDSIGNATURES
 
 Recursively adds subfolders of `helpers/` to LOAD_PATH.
 """
@@ -126,7 +126,7 @@ end
 
 
 """
-    load_configurations(root_dir::String = Genie.config.path_config; context::Union{Module,Nothing} = nothing) :: Nothing
+$TYPEDSIGNATURES
 
 Loads (includes) the framework's configuration files into the app's module `context`.
 The files are set up with `Revise` to be automatically reloaded.
@@ -154,7 +154,7 @@ end
 
 
 """
-    load_initializers(root_dir::String = Genie.config.path_config; context::Union{Module,Nothing} = nothing) :: Nothing
+$TYPEDSIGNATURES
 
 Loads (includes) the framework's initializers.
 The files are set up with `Revise` to be automatically reloaded.
@@ -174,7 +174,7 @@ end
 
 
 """
-    load_plugins(root_dir::String = Genie.config.path_plugins; context::Union{Module,Nothing} = nothing) :: Nothing
+$TYPEDSIGNATURES
 
 Loads (includes) the framework's plugins initializers.
 """
@@ -191,7 +191,7 @@ end
 
 
 """
-    load_routes_definitions(routes_file::String = Genie.ROUTES_FILE_NAME; context::Union{Module,Nothing} = nothing) :: Nothing
+$TYPEDSIGNATURES
 
 Loads the routes file.
 """
@@ -205,7 +205,7 @@ end
 const SECRET_TOKEN = Ref{String}("") # global state
 
 """
-    secret_token(generate_if_missing=true) :: String
+$TYPEDSIGNATURES
 
 Return the secret token used in the app for encryption and salting.
 
@@ -237,7 +237,7 @@ function secret_token(generate_if_missing::Bool = true; context::Union{Module,No
 end
 
 """
-    secret_token!(value=Generator.secret_token())
+$TYPEDSIGNATURES
 
 Define the secret token used in the app for encryption and salting.
 """
@@ -249,7 +249,7 @@ end
 
 
 """
-    default_context(context::Union{Module,Nothing})
+$TYPEDSIGNATURES
 
 Sets the module in which the code is loaded (the app's module)
 """
@@ -264,7 +264,7 @@ end
 
 
 """
-    load(; context::Union{Module,Nothing} = nothing) :: Nothing
+$TYPEDSIGNATURES
 
 Main entry point to loading a Genie app.
 """
@@ -305,9 +305,7 @@ end
 
 
 """
-    replprint(output::String, terminal;
-                    newline::Int = 0, clearline::Int = 1, color::Symbol = :white, bold::Bool = false, sleep_time::Float64 = 0.2,
-                    prefix::String = "", prefix_color::Symbol = :green, prefix_bold::Bool = true)
+$TYPEDSIGNATURES
 
 Prints app loading progress to the console.
 """

--- a/src/genie_types.jl
+++ b/src/genie_types.jl
@@ -4,19 +4,24 @@ import Base.show
 import Millboard
 
 
+
 """
-    to_dict(m::Any) :: Dict{String,Any}
-    to_string_dict(m::Any; all_output::Bool = false) :: Dict{String,String}
-    to_string_dict(m::Any, fields::Array{Symbol,1}; all_output::Bool = false) :: Dict{String,String}
+$TYPEDSIGNATURES
 
 Creates a `Dict` using the fields and the values of `m`.
 """
 function to_dict(m::Any) :: Dict{String,Any}
   Dict(string(f) => getfield(m, Symbol(f)) for f in fieldnames(typeof(m)))
 end
+"""
+$TYPEDSIGNATURES
+"""
 function to_string_dict(m::Any; all_output::Bool = false) :: Dict{String,String}
   to_string_dict(m, fieldnames(m), all_output = all_output)
 end
+"""
+$TYPEDSIGNATURES
+"""
 function to_string_dict(m::Any, fields::Array{Symbol,1}; all_output::Bool = false) :: Dict{String,String}
   response = Dict{String,String}()
   for f in fields

--- a/src/renderers/Html.jl
+++ b/src/renderers/Html.jl
@@ -1,5 +1,7 @@
 module Html
 
+using DocStringExtensionsMock
+
 import EzXML, HTTP, Logging, Markdown, Millboard, OrderedCollections, Reexport, YAML
 
 Reexport.@reexport using Genie
@@ -56,22 +58,34 @@ include("MdHtml.jl")
 
 
 """
-    normal_element(f::Function, elem::String, attrs::Vector{Pair{Symbol,Any}} = Pair{Symbol,Any}[]) :: HTMLString
+$TYPEDSIGNATURES
 
 Generates a HTML element in the form <...></...>
 """
 function normal_element(f::Function, elem::Any, args::Vector = [], attrs::Vector{Pair{Symbol,Any}} = Pair{Symbol,Any}[]) :: HTMLString
   normal_element(Base.invokelatest(f), string(elem), args, attrs...)
 end
+"""
+$TYPEDSIGNATURES
+"""
 function normal_element(children::Union{String,Vector{String}}, elem::Any, args::Vector, attrs::Pair{Symbol,Any}) :: HTMLString
   normal_element(children, string(elem), args, Pair{Symbol,Any}[attrs])
 end
+"""
+$TYPEDSIGNATURES
+"""
 function normal_element(children::Tuple, elem::Any, args::Vector, attrs::Pair{Symbol,Any}) :: HTMLString
   normal_element([children...], string(elem), args, Pair{Symbol,Any}[attrs])
 end
+"""
+$TYPEDSIGNATURES
+"""
 function normal_element(children::Union{String,Vector{String}}, elem::Any, args::Vector, attrs...) :: HTMLString
   normal_element(children, string(elem), args, Pair{Symbol,Any}[attrs...])
 end
+"""
+$TYPEDSIGNATURES
+"""
 function normal_element(children::Union{String,Vector{String}}, elem::Any, args::Vector = [], attrs::Vector{Pair{Symbol,Any}} = Pair{Symbol,Any}[]) :: HTMLString
   children = join(children)
 
@@ -97,9 +111,15 @@ function normal_element(children::Union{String,Vector{String}}, elem::Any, args:
     "</", elem, ">", (Genie.config.format_html_output ? "\n" : "") # closing tag
   )
 end
+"""
+$TYPEDSIGNATURES
+"""
 function normal_element(elem::Any, attrs::Vector{Pair{Symbol,Any}} = Pair{Symbol,Any}[]) :: HTMLString
   normal_element("", string(elem), attrs...)
 end
+"""
+$TYPEDSIGNATURES
+"""
 function normal_element(elems::Vector, elem::Any, args = [], attrs...) :: HTMLString
   io = IOBuffer()
 
@@ -117,14 +137,23 @@ function normal_element(elems::Vector, elem::Any, args = [], attrs...) :: HTMLSt
 
   normal_element(String(take!(io)), string(elem), args, attrs...)
 end
+"""
+$TYPEDSIGNATURES
+"""
 function normal_element(_::Nothing, __::Any) :: HTMLString
   ""
 end
+"""
+$TYPEDSIGNATURES
+"""
 function normal_element(children::Vector{T}, elem::Any, args::Vector{T})::HTMLString where {T}
   normal_element(join([(isa(f, Function) ? f() : string(f)) for f in children]), elem, args)
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function extractindent!(attrs) :: String
   indent = if Genie.config.format_html_output
     htmlsidx = findfirst(x -> x == :htmlsourceindent, getindex.(attrs, 1))
@@ -145,14 +174,18 @@ end
 
 
 """
-    prepare_template(s::String)
-    prepare_template{T}(v::Vector{T})
+$TYPEDSIGNATURES
+
+prepare_template{T}(v::Vector{T})
 
 Cleans up the template before rendering (ex by removing empty nodes).
 """
 function prepare_template(s::String) :: String
   s
 end
+"""
+$TYPEDSIGNATURES
+"""
 function prepare_template(v::Vector{T})::String where {T}
   filter!(v) do (x)
     ! isa(x, Nothing)
@@ -163,7 +196,7 @@ end
 
 
 """
-    attributes(attrs::Vector{Pair{Symbol,String}} = Vector{Pair{Symbol,String}}()) :: Vector{String}
+$TYPEDSIGNATURES
 
 Parses HTML attributes.
 """
@@ -181,26 +214,38 @@ function attributes(attrs::Vector{Pair{Symbol,Any}} = Vector{Pair{Symbol,Any}}()
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function attrparser(k::Symbol, v::Bool) :: String
   v ? "$(k |> parseattr) " : ""
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function attrparser(k::Symbol, v::Union{AbstractString,Symbol}) :: String
   isempty(string(v)) && return attrparser(k, true)
   "$(k |> parseattr)=\"$(v)\" "
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function attrparser(k::Symbol, v::Any) :: String
   default_attrparser(k, v)
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function default_attrparser(k::Symbol, v::Any) :: String
   "$(k |> parseattr)=$(v) "
 end
 
 
 """
-    parseattr(attr) :: String
+$TYPEDSIGNATURES
 
 Converts Julia keyword arguments to HTML attributes with illegal Julia chars.
 """
@@ -221,7 +266,7 @@ end
 
 
 """
-    normalize_element(elem::String)
+$TYPEDSIGNATURES
 
 Cleans up problematic characters or DOM elements.
 """
@@ -231,7 +276,7 @@ end
 
 
 """
-    denormalize_element(elem::String)
+$TYPEDSIGNATURES
 
 Replaces `-` with the char defined to replace dashes, as Julia does not support them in names.
 """
@@ -243,7 +288,7 @@ end
 
 
 """
-    void_element(elem::String, attrs::Vector{Pair{Symbol,String}} = Vector{Pair{Symbol,String}}()) :: HTMLString
+$TYPEDSIGNATURES
 
 Generates a void HTML element in the form <...>
 """
@@ -258,7 +303,7 @@ end
 
 
 """
-    get_template(path::String; partial::Bool = true, context::Module = @__MODULE__, vars...) :: Function
+$TYPEDSIGNATURES
 
 Resolves the inclusion and rendering of a template file
 """
@@ -293,18 +338,21 @@ end
 
 
 """
-Outputs document's doctype.
+$TYPEDSIGNATURES
 """
 function doc(html::String) :: HTMLString
   string(doctype(), html)
 end
+"""
+$TYPEDSIGNATURES
+"""
 function doc(doctype::Symbol, html::String) :: HTMLString
   string(doctype(doctype), html)
 end
 
 
 """
-    parseview(data::String; partial = false, context::Module = @__MODULE__) :: Function
+$TYPEDSIGNATURES
 
 Parses a view file, returning a rendering function. If necessary, the function is JIT-compiled, persisted and loaded into memory.
 """
@@ -330,7 +378,7 @@ end
 
 
 """
-    render(data::String; context::Module = @__MODULE__, layout::Union{String,Nothing} = nothing, vars...) :: Function
+$TYPEDSIGNATURES
 
 Renders the string as an HTML view.
 """
@@ -347,7 +395,7 @@ end
 
 
 """
-    render(viewfile::Genie.Renderer.FilePath; layout::Union{Nothing,Genie.Renderer.FilePath} = nothing, context::Module = @__MODULE__, vars...) :: Function
+$TYPEDSIGNATURES
 
 Renders the template file as an HTML view.
 """
@@ -364,9 +412,7 @@ end
 
 
 """
-    parsehtml(input::String; partial::Bool = true) :: String
-
-
+$TYPEDSIGNATURES
 """
 function parsehtml(input::String; partial::Bool = true) :: String
   content = replace(input, NBSP_REPLACEMENT)
@@ -375,6 +421,9 @@ function parsehtml(input::String; partial::Bool = true) :: String
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function Genie.Renderer.render(::Type{MIME"text/html"}, data::String; context::Module = @__MODULE__, layout::Union{String,Nothing} = nothing, vars...) :: Genie.Renderer.WebRenderable
   try
     render(data; context = context, layout = layout, vars...) |> Genie.Renderer.WebRenderable
@@ -385,6 +434,9 @@ function Genie.Renderer.render(::Type{MIME"text/html"}, data::String; context::M
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function Genie.Renderer.render(::Type{MIME"text/html"}, viewfile::Genie.Renderer.FilePath; layout::Union{Nothing,Genie.Renderer.FilePath} = nothing, context::Module = @__MODULE__, vars...) :: Genie.Renderer.WebRenderable
   try
     render(viewfile; layout = layout, context = context, vars...) |> Genie.Renderer.WebRenderable
@@ -395,6 +447,9 @@ function Genie.Renderer.render(::Type{MIME"text/html"}, viewfile::Genie.Renderer
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function html(resource::Genie.Renderer.ResourcePath, action::Genie.Renderer.ResourcePath;
                 layout::Union{Genie.Renderer.ResourcePath,Nothing} = DEFAULT_LAYOUT_FILE,
                 context::Module = @__MODULE__, status::Int = 200, headers::Genie.Renderer.HTTPHeaders = Genie.Renderer.HTTPHeaders(), vars...) :: Genie.Renderer.HTTP.Response
@@ -405,7 +460,7 @@ end
 
 
 """
-    html(data::String; context::Module = @__MODULE__, status::Int = 200, headers::HTTPHeaders = HTTPHeaders(), layout::Union{String,Nothing} = nothing, vars...) :: HTTP.Response
+$TYPEDSIGNATURES
 
 Parses the `data` input as HTML, returning a HTML HTTP Response.
 
@@ -441,7 +496,7 @@ end
 
 
 """
-    html(md::Markdown.MD; context::Module = @__MODULE__, status::Int = 200, headers::Genie.Renderer.HTTPHeaders = Genie.Renderer.HTTPHeaders(), layout::Union{String,Nothing} = nothing, forceparse::Bool = false, vars...) :: Genie.Renderer.HTTP.Response
+$TYPEDSIGNATURES
 
 Markdown view rendering
 """
@@ -456,8 +511,7 @@ end
 
 
 """
-    html(viewfile::FilePath; layout::Union{Nothing,FilePath} = nothing,
-          context::Module = @__MODULE__, status::Int = 200, headers::HTTPHeaders = HTTPHeaders(), vars...) :: HTTP.Response
+$TYPEDSIGNATURES
 
 Parses and renders the HTML `viewfile`, optionally rendering it within the `layout` file. Valid file format is `.html.jl`.
 
@@ -475,7 +529,7 @@ end
 
 
 """
-    safe_attr(attr) :: String
+$TYPEDSIGNATURES
 
 Replaces illegal Julia characters from HTML attributes with safe ones, to be used as keyword arguments.
 """
@@ -491,6 +545,9 @@ function safe_attr(attr) :: String
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function parse_attributes!(elem_attributes, io::IOBuffer) :: IOBuffer
   attributes = IOBuffer()
   attributes_keys = String[]
@@ -564,7 +621,7 @@ end
 
 
 """
-    parsehtml(elem, output; partial = true) :: String
+$TYPEDSIGNATURES
 
 Parses a HTML tree structure into a `string` of Julia code.
 """
@@ -651,6 +708,9 @@ function parsehtml(elem::HTMLParser.Node; partial::Bool = true, indent = 0) :: S
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function parsenode(elem::HTMLParser.Node; partial::Bool = true) :: String
   content = elem |> HTMLParser.nodecontent
   endswith(content, "\"") && (content *= Char(0x0))
@@ -662,7 +722,7 @@ end
 
 
 """
-    html_to_julia(file_path::String; partial = true) :: String
+$TYPEDSIGNATURES
 
 Converts a HTML document to Julia code.
 """
@@ -672,7 +732,7 @@ end
 
 
 """
-    string_to_julia(content::String; partial = true, f_name::Union{Symbol,Nothing} = nothing, prepend = "") :: String
+$TYPEDSIGNATURES
 
 Converts string view data to Julia code
 """
@@ -681,11 +741,11 @@ function string_to_julia(content::String; partial = true, f_name::Union{Symbol,N
 end
 
 
-"""
-    to_julia(input::String, f::Function; partial = true, f_name::Union{Symbol,Nothing} = nothing, prepend = "") :: String
-
-Converts an input file to Julia code
-"""
+  """  
+  $TYPEDSIGNATURES
+  
+  Converts an input file to Julia code
+  """
   function to_julia(input::String, f::Union{Function,Nothing};
                   partial = true, f_name::Union{Symbol,Nothing} = nothing, prepend::String = "\n", extension = TEMPLATE_EXT) :: String
   f_name = (f_name === nothing) ? Genie.Renderer.function_name(string(input, partial)) : f_name
@@ -709,7 +769,7 @@ end
 
 
 """
-    partial(path::String; context::Module = @__MODULE__, vars...) :: String
+$TYPEDSIGNATURES
 
 Renders (includes) a view partial within a larger view or layout file.
 """
@@ -721,12 +781,15 @@ function partial(path::String; context::Module = @__MODULE__, kwvars...) :: Stri
   template(path, partial = true, context = context)
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function partial(path::Genie.Renderer.FilePath; context::Module = @__MODULE__, kwvars...)
   partial(string(path); context = context, kwvars...)
 end
 
 """
-    template(path::String; partial::Bool = true, context::Module = @__MODULE__, vars...) :: String
+$TYPEDSIGNATURES
 
 Renders a template file.
 """
@@ -744,7 +807,7 @@ end
 
 
 """
-    read_template_file(file_path::String) :: String
+$TYPEDSIGNATURES
 
 Reads `file_path` template from disk.
 """
@@ -771,7 +834,7 @@ end
 
 
 """
-    parse_template(file_path::String; partial = true) :: String
+$TYPEDSIGNATURES
 
 Parses a HTML file into Julia code.
 """
@@ -781,7 +844,7 @@ end
 
 
 """
-    parse_string(data::String; partial = true) :: String
+$TYPEDSIGNATURES
 
 Parses a HTML string into Julia code.
 """
@@ -790,11 +853,17 @@ function parse_string(data::String; partial::Bool = true, extension = TEMPLATE_E
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function parse(input::String; partial::Bool = true) :: String
   parsehtml(input, partial = partial)
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function parse_embed_tags(code::String) :: String
   replace(
     replace(code, "<%"=>"""<script type="julia/eval">"""),
@@ -803,7 +872,7 @@ end
 
 
 """
-    register_elements() :: Nothing
+$TYPEDSIGNATURES
 
 Generated functions that represent Julia functions definitions corresponding to HTML elements.
 """
@@ -830,7 +899,7 @@ end
 
 
 """
-    register_element(elem::Union{Symbol,String}, elem_type::Union{Symbol,String} = :normal; context = @__MODULE__) :: Nothing
+$TYPEDSIGNATURES
 
 Generates a Julia function representing an HTML element.
 """
@@ -843,7 +912,7 @@ end
 
 
 """
-    register_normal_element(elem::Union{Symbol,String}; context = @__MODULE__) :: Nothing
+$TYPEDSIGNATURES
 
 Generates a Julia function representing a "normal" HTML element: that is an element with a closing tag, <tag>...</tag>
 """
@@ -879,7 +948,7 @@ end
 
 
 """
-    register_void_element(elem::Union{Symbol,String}; context::Module = @__MODULE__) :: Nothing
+$TYPEDSIGNATURES
 
 Generates a Julia function representing a "void" HTML element: that is an element without a closing tag, <tag />
 """
@@ -897,7 +966,7 @@ end
 
 
 """
-    for_each(f::Function, v)
+$TYPEDSIGNATURES
 
 Iterates over the `v` Vector and applies function `f` for each element.
 The results of each iteration are concatenated and the final string is returned.
@@ -908,7 +977,7 @@ end
 
 
 """
-    collection(template::Function, collection::Vector{T})::String where {T}
+$TYPEDSIGNATURES
 
 Creates a view fragment by repeateadly applying a function to each element of the collection.
 """
@@ -924,7 +993,7 @@ end
 
 
 """
-    Genie.Router.error(error_message::String, ::Type{MIME"text/html"}, ::Val{500}; error_info::String = "") :: HTTP.Response
+$TYPEDSIGNATURES
 
 Returns a 500 error response as an HTML doc.
 """
@@ -934,7 +1003,7 @@ end
 
 
 """
-    Genie.Router.error(error_message::String, ::Type{MIME"text/html"}, ::Val{404}; error_info::String = "") :: HTTP.Response
+$TYPEDSIGNATURES
 
 Returns a 404 error response as an HTML doc.
 """
@@ -944,7 +1013,7 @@ end
 
 
 """
-    Genie.Router.error(error_code::Int, error_message::String, ::Type{MIME"text/html"}; error_info::String = "") :: HTTP.Response
+$TYPEDSIGNATURES
 
 Returns an error response as an HTML doc.
 """
@@ -954,7 +1023,7 @@ end
 
 
 """
-    serve_error_file(error_code::Int, error_message::String = "", params::Dict{Symbol,Any} = Dict{Symbol,Any}()) :: Response
+$TYPEDSIGNATURES
 
 Serves the error file correspoding to `error_code` and current environment.
 """
@@ -1015,15 +1084,24 @@ macro yield(value)
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function view!()
   haskey(task_local_storage(), :__yield) ? task_local_storage(:__yield) : task_local_storage(:__yield, String[])
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function view!(value)
   task_local_storage(:__yield, value)
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function el(; vars...)
   OrderedCollections.OrderedDict(vars)
 end

--- a/src/renderers/Js.jl
+++ b/src/renderers/Js.jl
@@ -1,5 +1,7 @@
 module Js
 
+using DocStringExtensionsMock
+
 import Logging, HTTP, Reexport
 
 Reexport.@reexport using Genie
@@ -17,6 +19,9 @@ const NBSP_REPLACEMENT = ("&nbsp;"=>"!!nbsp;;")
 export js
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function get_template(path::String; context::Module = @__MODULE__, vars...) :: Function
   orig_path = path
 
@@ -44,6 +49,9 @@ function get_template(path::String; context::Module = @__MODULE__, vars...) :: F
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function to_js(data::String; prepend = "\n", extension = TEMPLATE_EXT) :: String
   output = string("function $(Genie.Renderer.function_name(data))($(Genie.Renderer.injectkwvars())) :: String \n", prepend)
 
@@ -61,6 +69,9 @@ function to_js(data::String; prepend = "\n", extension = TEMPLATE_EXT) :: String
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function render(data::String; context::Module = @__MODULE__, vars...) :: Function
   Genie.Renderer.registervars(; context = context, vars...)
 
@@ -82,6 +93,9 @@ function render(data::String; context::Module = @__MODULE__, vars...) :: Functio
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function render(viewfile::Genie.Renderer.FilePath; context::Module = @__MODULE__, vars...) :: Function
   Genie.Renderer.registervars(; context = context, vars...)
 
@@ -89,6 +103,9 @@ function render(viewfile::Genie.Renderer.FilePath; context::Module = @__MODULE__
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function render(::Type{MIME"application/javascript"}, data::String; context::Module = @__MODULE__, vars...) :: Genie.Renderer.WebRenderable
   try
     Genie.Renderer.WebRenderable(render(data; context = context, vars...), :javascript)
@@ -99,6 +116,9 @@ function render(::Type{MIME"application/javascript"}, data::String; context::Mod
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function render(::Type{MIME"application/javascript"}, viewfile::Genie.Renderer.FilePath; context::Module = @__MODULE__, vars...) :: Genie.Renderer.WebRenderable
   try
     Genie.Renderer.WebRenderable(render(viewfile; context = context, vars...), :javascript)
@@ -109,6 +129,9 @@ function render(::Type{MIME"application/javascript"}, viewfile::Genie.Renderer.F
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function js(data::String; context::Module = @__MODULE__, status::Int = 200,
             headers::Genie.Renderer.HTTPHeaders = Genie.Renderer.HTTPHeaders("Content-Type" => Genie.Renderer.CONTENT_TYPES[:javascript]),
             forceparse::Bool = false, vars...) :: Genie.Renderer.HTTP.Response
@@ -120,6 +143,9 @@ function js(data::String; context::Module = @__MODULE__, status::Int = 200,
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function js(viewfile::Genie.Renderer.FilePath; context::Module = @__MODULE__, status::Int = 200,
             headers::Genie.Renderer.HTTPHeaders = Genie.Renderer.HTTPHeaders("Content-Type" => Genie.Renderer.CONTENT_TYPES[:javascript]), vars...) :: Genie.Renderer.HTTP.Response
   Genie.Renderer.WebRenderable(render(MIME"application/javascript", viewfile; context = context, vars...), :javascript, status, headers) |> Genie.Renderer.respond
@@ -130,16 +156,25 @@ end
 ### EXCEPTIONS ###
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function Genie.Router.error(error_message::String, ::Type{MIME"application/javascript"}, ::Val{500}; error_info::String = "") :: HTTP.Response
   HTTP.Response(Dict("error" => "500 Internal Error - $error_message", "info" => error_info), status = 500) |> js
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function Genie.Router.error(error_message::String, ::Type{MIME"application/javascript"}, ::Val{404}; error_info::String = "") :: HTTP.Response
   HTTP.Response(Dict("error" => "404 Not Found - $error_message", "info" => error_info), status = 404) |> js
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function Genie.Router.error(error_code::Int, error_message::String, ::Type{MIME"application/javascript"}; error_info::String = "") :: HTTP.Response
   HTTP.Response(Dict("error" => "$error_code Error - $error_message", "info" => error_info), status = error_code) |> js
 end

--- a/src/renderers/Json.jl
+++ b/src/renderers/Json.jl
@@ -1,5 +1,7 @@
 module Json
 
+using DocStringExtensionsMock
+
 import JSON3, HTTP, Reexport
 
 Reexport.@reexport using Genie
@@ -24,6 +26,9 @@ const JSONString = String
 export JSONString, json
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function render(viewfile::Genie.Renderer.FilePath; context::Module = @__MODULE__, vars...) :: Function
   Genie.Renderer.registervars(; context = context, vars...)
 
@@ -58,27 +63,42 @@ function render(viewfile::Genie.Renderer.FilePath; context::Module = @__MODULE__
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function render(data::Any; forceparse::Bool = false, context::Module = @__MODULE__) :: Function
   () -> JSONParser.json(data)
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function Genie.Renderer.render(::Type{MIME"application/json"}, datafile::Genie.Renderer.FilePath; context::Module = @__MODULE__, vars...) :: Genie.Renderer.WebRenderable
   Genie.Renderer.WebRenderable(render(datafile; context = context, vars...), :json)
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function Genie.Renderer.render(::Type{MIME"application/json"}, data::String; context::Module = @__MODULE__, vars...) :: Genie.Renderer.WebRenderable
   Genie.Renderer.WebRenderable(render(data; context = context, vars...), :json)
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function Genie.Renderer.render(::Type{MIME"application/json"}, data::Any; context::Module = @__MODULE__, vars...) :: Genie.Renderer.WebRenderable
   Genie.Renderer.WebRenderable(render(data), :json)
 end
 
 ### json API
 
+"""
+$TYPEDSIGNATURES
+"""
 function json(resource::Genie.Renderer.ResourcePath, action::Genie.Renderer.ResourcePath; context::Module = @__MODULE__,
               status::Int = 200, headers::Genie.Renderer.HTTPHeaders = Genie.Renderer.HTTPHeaders(), vars...) :: Genie.Renderer.HTTP.Response
   json(Genie.Renderer.Path(joinpath(Genie.config.path_resources, string(resource), Renderer.VIEWS_FOLDER, string(action) * JSON_FILE_EXT));
@@ -86,18 +106,27 @@ function json(resource::Genie.Renderer.ResourcePath, action::Genie.Renderer.Reso
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function json(datafile::Genie.Renderer.FilePath; context::Module = @__MODULE__,
               status::Int = 200, headers::Genie.Renderer.HTTPHeaders = Genie.Renderer.HTTPHeaders(), vars...) :: Genie.Renderer.HTTP.Response
   Genie.Renderer.WebRenderable(Genie.Renderer.render(MIME"application/json", datafile; context = context, vars...), :json, status, headers) |> Genie.Renderer.respond
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function json(data::String; context::Module = @__MODULE__,
               status::Int = 200, headers::Genie.Renderer.HTTPHeaders = Genie.Renderer.HTTPHeaders(), vars...) :: Genie.Renderer.HTTP.Response
   Genie.Renderer.WebRenderable(Genie.Renderer.render(MIME"application/json", data; context = context, vars...), :json, status, headers) |> Genie.Renderer.respond
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function json(data::Any; status::Int = 200, headers::Genie.Renderer.HTTPHeaders = Genie.Renderer.HTTPHeaders()) :: Genie.Renderer.HTTP.Response
   Genie.Renderer.WebRenderable(Genie.Renderer.render(MIME"application/json", data), :json, status, headers) |> Genie.Renderer.respond
 end
@@ -107,16 +136,25 @@ end
 ### EXCEPTIONS ###
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function Genie.Router.error(error_message::String, ::Type{MIME"application/json"}, ::Val{500}; error_info::String = "") :: HTTP.Response
   json(Dict("error" => "500 Internal Error - $error_message", "info" => error_info), status = 500)
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function Genie.Router.error(error_message::String, ::Type{MIME"application/json"}, ::Val{404}; error_info::String = "") :: HTTP.Response
   json(Dict("error" => "404 Not Found - $error_message", "info" => error_info), status = 404)
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function Genie.Router.error(error_code::Int, error_message::String, ::Type{MIME"application/json"}; error_info::String = "") :: HTTP.Response
   json(Dict("error" => "$error_code Error - $error_message", "info" => error_info), status = error_code)
 end

--- a/src/renderers/MdHtml.jl
+++ b/src/renderers/MdHtml.jl
@@ -1,4 +1,5 @@
 module MdHtml
+using DocStringExtensionsMock
 
 import Reexport, Markdown, YAML
 
@@ -9,6 +10,9 @@ const MD_SEPARATOR_START = "---"
 const MD_SEPARATOR_END   = "---"
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function md_to_html(path::String; context::Module = @__MODULE__) :: String
   Genie.Renderer.build_module(
 """
@@ -32,7 +36,7 @@ end
 
 
 """
-    eval_markdown(md::String; context::Module = @__MODULE__) :: String
+$TYPEDSIGNATURES
 
 Converts the mardown `md` to HTML view code.
 """

--- a/src/renderers/html/form.jl
+++ b/src/renderers/html/form.jl
@@ -2,10 +2,16 @@ function form(f::Function, args...; attrs...) :: HTMLString
   normal_element(f, "form", [args...], attr(attrs...))
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function form(children::Union{String,Vector{String}} = "", args...; attrs...) :: HTMLString
   normal_element(children, "form", [args...], attr(attrs...))
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function attr(attrs...)
   attrs = Pair{Symbol,Any}[attrs...]
 

--- a/src/renderers/html/select.jl
+++ b/src/renderers/html/select.jl
@@ -5,11 +5,17 @@ Base.@kwdef struct Option
   text::String = value
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function option(disabled::Bool, selected::Bool, value::String, text::String)
   Option(; disabled = disabled, selected = selected, value = value, text = text)
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function Base.string(o::Option) :: HTMLString
   attributes = String[]
 
@@ -21,6 +27,9 @@ function Base.string(o::Option) :: HTMLString
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function select(options::Vector{Option}, args...; attrs...) :: HTMLString
   children = String[]
 
@@ -32,16 +41,25 @@ function select(options::Vector{Option}, args...; attrs...) :: HTMLString
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function select(options::Vector, args...; attrs...) :: HTMLString
   select([option(o) for o in options], args...; attrs...)
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function select(options::Tuple, args...; attrs...) :: HTMLString
   select([option(o) for o in [options...]], args...; attrs...)
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function optgroup(options::Vector{Option}, args...; attrs...) :: HTMLString
   children = String[]
 

--- a/src/session_adapters/FileSession.jl
+++ b/src/session_adapters/FileSession.jl
@@ -6,7 +6,7 @@ import Serialization, Logging
 const SESSIONS_PATH = "sessions"
 
 """
-    write(session::Genie.Sessions.Session) :: Genie.Sessions.Session
+$TYPEDSIGNATURES
 
 Persists the `Session` object to the file system, using the configured sessions folder and returns it.
 """
@@ -50,6 +50,9 @@ function write(session::Genie.Sessions.Session) :: Genie.Sessions.Session
 end
 
 
+"""
+$TYPEDSIGNATURES
+"""
 function write_session(session::Genie.Sessions.Session)
   open(joinpath(SESSIONS_PATH, session.id), "w") do io
     Serialization.serialize(io, session)
@@ -58,8 +61,7 @@ end
 
 
 """
-    read(session_id::Union{String,Symbol}) :: Union{Nothing,Genie.Sessions.Session}
-    read(session::Genie.Sessions.Session) :: Union{Nothing,Genie.Sessions.Session}
+$TYPEDSIGNATURES
 
 Attempts to read from file the session object serialized as `session_id`.
 """
@@ -76,6 +78,9 @@ function read(session_id::Union{String,Symbol}) :: Union{Nothing,Genie.Sessions.
   end
 end
 
+"""
+$TYPEDSIGNATURES
+"""
 function read(session::Genie.Sessions.Session) :: Union{Nothing,Genie.Sessions.Session}
   read(session.id)
 end
@@ -84,7 +89,7 @@ end
 # IMPLEMENTATION
 
 """
-    persist(s::Session) :: Session
+$TYPEDSIGNATURES
 
 Generic method for persisting session data - delegates to the underlying `SessionAdapter`.
 """
@@ -96,7 +101,7 @@ end
 
 
 """
-    load(session_id::String) :: Session
+$TYPEDSIGNATURES
 
 Loads session data from persistent storage.
 """

--- a/test/tests_cache.jl
+++ b/test/tests_cache.jl
@@ -3,6 +3,9 @@
 
   Cache.init()
 
+  """  
+  $TYPEDSIGNATURES
+  """
   function f()
     rand(1:1_000)
   end
@@ -28,6 +31,9 @@ end
 @safetestset "cache" begin
   using Genie, Genie.Cache
 
+  """  
+  $TYPEDSIGNATURES
+  """
   function f()
     rand(1:1_000)
   end

--- a/test/tests_files_vars_rendering.jl
+++ b/test/tests_files_vars_rendering.jl
@@ -8,6 +8,9 @@
   greeting = "Welcome"
   name = "Genie"
 
+  """  
+  $TYPEDSIGNATURES
+  """
   function htmlviewfile_withvars()
     raw"
     <h1>$(vars(:greeting))</h1>
@@ -18,6 +21,9 @@
     "
   end
 
+  """  
+  $TYPEDSIGNATURES
+  """
   function htmltemplatefile_withvars()
     raw"
     <!DOCTYPE HTML>

--- a/test/tests_html_rendering.jl
+++ b/test/tests_html_rendering.jl
@@ -4,6 +4,9 @@
   greeting = "Welcome"
   name = "Genie"
 
+  """  
+  $TYPEDSIGNATURES
+  """
   function htmlviewfile()
     "
     <h1>$greeting</h1>
@@ -14,6 +17,9 @@
     "
   end
 
+  """  
+  $TYPEDSIGNATURES
+  """
   function htmltemplatefile()
     "
     <!DOCTYPE HTML>

--- a/test/tests_vars_rendering.jl
+++ b/test/tests_vars_rendering.jl
@@ -5,6 +5,9 @@
   greeting = "Welcome"
   name = "Genie"
 
+  """  
+  $TYPEDSIGNATURES
+  """
   function htmlviewfile_withvars()
     raw"
     <h1>$(vars(:greeting))</h1>
@@ -15,6 +18,9 @@
     "
   end
 
+  """  
+  $TYPEDSIGNATURES
+  """
   function htmltemplatefile_withvars()
     raw"
     <!DOCTYPE HTML>


### PR DESCRIPTION
resolves #416 by adding function signatures to the docstrings of all functions.  Uses a local DocStringExtensionsMock.jl file to mock the DocStringExtensions package to not have an external dependency.

Suggestions welcomed for how to get rid of this warning:

```
┌ Warning: Package Genie does not have DocStringExtensionsMock in its dependencies:
│ - If you have Genie checked out for development and have
│   added DocStringExtensionsMock as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with Genie
└ Loading DocStringExtensionsMock into Genie from project dependency, future warnings for Genie are suppressed.
```

To get the full benefit of this, if accepted, the docs repo should have DocStringExtensions added as a dependency, and then all of the docs should have docstrings now. :)