### PR TITLE
Julia 1.7 compatibility: define ncodeunits for ParsedHTMLString and HTMLString

### DIFF
--- a/src/renderers/Html.jl
+++ b/src/renderers/Html.jl
@@ -63,6 +63,8 @@ Base.String(s::ParsedHTMLString) = string(s)
 Base.iterate(s::ParsedHTMLString) = iterate(s.data)
 Base.iterate(s::ParsedHTMLString, x::Int) = iterate(s.data, x)
 
+Base.ncodeunits(s::ParsedHTMLString) = Base.ncodeunits(s.data)
+
 Base.convert(::Type{ParsedHTMLString}, v::Vector{T}) where {T} = ParsedHTMLString(v)
 
 import Base: (*)
@@ -89,6 +91,8 @@ Base.String(s::HTMLString) = string(s)
 
 Base.iterate(s::HTMLString) = iterate(s.data)
 Base.iterate(s::HTMLString, x::Int) = iterate(s.data, x)
+
+Base.ncodeunits(s::HTMLString) = Base.ncodeunits(s.data)
 
 Base.convert(::Type{HTMLString}, v::Vector{T}) where {T} = HTMLString(v)
 


### PR DESCRIPTION
Currently `Base.show()` for `ParsedHTMLString` and `HTMLString` fail at the REPL for Julia 1.7

```julia
julia> HTMLString("hh")
Error showing value of type HTMLString:
ERROR: MethodError: no method matching ncodeunits(::HTMLString)
Closest candidates are:
  ncodeunits(::SubString) at C:\Julia\julia-1.7.0\share\julia\base\strings\substring.jl:64
  ncodeunits(::SubstitutionString) at C:\Julia\julia-1.7.0\share\julia\base\regex.jl:548
  ncodeunits(::Char) at C:\Julia\julia-1.7.0\share\julia\base\char.jl:65
  ...
Stacktrace:
  [1] show(io::IOContext{Base.TTY}, mime::MIME{Symbol("text/plain")}, str::HTMLString; limit::Nothing)
    @ Base .\strings\io.jl:211
  [2] show(io::IOContext{Base.TTY}, mime::MIME{Symbol("text/plain")}, str::HTMLString)
    @ Base .\strings\io.jl:203
  [3] (::REPL.var"#43#44"{REPL.REPLDisplay{REPL.LineEditREPL}, MIME{Symbol("text/plain")}, Base.RefValue{Any}})(io::Any)
    @ REPL C:\Julia\julia-1.7.0\share\julia\stdlib\v1.7\REPL\src\REPL.jl:264
  [4] with_repl_linfo(f::Any, repl::REPL.LineEditREPL)
    @ REPL C:\Julia\julia-1.7.0\share\julia\stdlib\v1.7\REPL\src\REPL.jl:508
  [5] display(d::REPL.REPLDisplay, mime::MIME{Symbol("text/plain")}, x::Any)
    @ REPL C:\Julia\julia-1.7.0\share\julia\stdlib\v1.7\REPL\src\REPL.jl:257
  [6] display(d::REPL.REPLDisplay, x::Any)
    @ REPL C:\Julia\julia-1.7.0\share\julia\stdlib\v1.7\REPL\src\REPL.jl:269
  [7] display(x::Any)
    @ Base.Multimedia .\multimedia.jl:328
  [8] #invokelatest#2
    @ .\essentials.jl:716 [inlined]
  [9] invokelatest
    @ .\essentials.jl:714 [inlined]
 [10] print_response(errio::IO, response::Any, show_value::Bool, have_color::Bool, specialdisplay::Union{Nothing, AbstractDisplay})
    @ REPL C:\Julia\julia-1.7.0\share\julia\stdlib\v1.7\REPL\src\REPL.jl:291
 [11] (::REPL.var"#45#46"{REPL.LineEditREPL, Pair{Any, Bool}, Bool, Bool})(io::Any)
    @ REPL C:\Julia\julia-1.7.0\share\julia\stdlib\v1.7\REPL\src\REPL.jl:275
 [12] with_repl_linfo(f::Any, repl::REPL.LineEditREPL)
    @ REPL C:\Julia\julia-1.7.0\share\julia\stdlib\v1.7\REPL\src\REPL.jl:508
 [13] print_response(repl::REPL.AbstractREPL, response::Any, show_value::Bool, have_color::Bool)
    @ REPL C:\Julia\julia-1.7.0\share\julia\stdlib\v1.7\REPL\src\REPL.jl:273
 [14] (::REPL.var"#do_respond#66"{Bool, Bool, REPL.var"#77#87"{REPL.LineEditREPL, REPL.REPLHistoryProvider}, REPL.LineEditREPL, REPL.LineEdit.Prompt})(s::REPL.LineEdit.MIState, buf::Any, ok::Bool)
    @ REPL C:\Julia\julia-1.7.0\share\julia\stdlib\v1.7\REPL\src\REPL.jl:844
 [15] #invokelatest#2
    @ .\essentials.jl:716 [inlined]
 [16] invokelatest
    @ .\essentials.jl:714 [inlined]
 [17] run_interface(terminal::REPL.Terminals.TextTerminal, m::REPL.LineEdit.ModalInterface, s::REPL.LineEdit.MIState)
    @ REPL.LineEdit C:\Julia\julia-1.7.0\share\julia\stdlib\v1.7\REPL\src\LineEdit.jl:2493
 [18] run_frontend(repl::REPL.LineEditREPL, backend::REPL.REPLBackendRef)
    @ REPL C:\Julia\julia-1.7.0\share\julia\stdlib\v1.7\REPL\src\REPL.jl:1230
 [19] (::REPL.var"#49#54"{REPL.LineEditREPL, REPL.REPLBackendRef})()
    @ REPL .\task.jl:423
```

This PR fixes this issue.