### PR TITLE
fix base_path behavior for webchannels

### DIFF
--- a/assets/js/channels.js
+++ b/assets/js/channels.js
@@ -63,7 +63,8 @@ Genie.WebChannels.load_channels = function() {
 
 function newSocketConnection() {
   try {
-    return new WebSocket(window.location.protocol.replace('http', 'ws') + '//' + window.location.hostname + ':' + Genie.WebChannels.port);
+    return new WebSocket(window.location.protocol.replace('http', 'ws') + '//' + window.location.hostname + 
+      ':' + Genie.WebChannels.port + (Genie.Settings.base_path == '' ? '' : '/' + Genie.Settings.base_path));
   } catch (e) {
     console.error(e);
   }


### PR DESCRIPTION
If a genie app lives behind a reverse proxy with a base_path, websockets need to be established via the base_path. In webthreads this is already implemented, afaics.

@essenciary Currently, the base_path is lowercased. Is there any special reason for that?
