### PR TITLE
Use CSPRNG in Sessions.id()

### DIFF
--- a/test/tests_Sessions_id.jl
+++ b/test/tests_Sessions_id.jl
@@ -1,0 +1,6 @@
+@safetestset "Sessions id test" begin
+    using Genie
+
+    @test !isempty(Genie.secret_token())
+    @test Genie.Sessions.id() != Genie.Sessions.id()
+end;


### PR DESCRIPTION
Fixes [Session key generation uses insecure random generator #162
](https://github.com/GenieFramework/Genie.jl/issues/162)