### PR TITLE
Fix link to tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ end
 ```
 
 * `Logging System` | `Caching` | `Cookies and Sessions` | `Built in Docker and Heroku Integrations` | `Genie Deploy`
-* To explore more features check [Genie Documentation](https://www.genieframework.com/docs/tutorials/Overview.html) 🏃‍♂️🏃‍♀️
+* To explore more features check [Genie Documentation](https://www.genieframework.com/docs/genie/tutorials/Overview.html) 🏃‍♂️🏃‍♀️
 
 ## **Made With Genie**
 - Packages/Libraries:


### PR DESCRIPTION
After the last refactor of https://www.genieframework.com/docs/ the previous link does not work. The working link is now [https://www.genieframework.com/docs/genie/tutorials/Overview.html](https://www.genieframework.com/docs/genie/tutorials/Overview.html)