### PR TITLE
Fix attribute parsing

### DIFF
--- a/src/renderers/Html.jl
+++ b/src/renderers/Html.jl
@@ -724,10 +724,11 @@ function parsehtml(elem::HTMLParser.Node; partial::Bool = true, indent = 0) :: S
         try
           attrs_dict[a.name] = elem[a.name]
         catch ex
-          parts = split(string(a), '=')
+          attr = string(a)
+          parts = split(attr, '=')
 
-          if length(parts) == 2
-            val = strip(parts[2])
+          if length(parts) >= 2
+            val = attr[(findfirst(c->c.=='=', attr)+1):end]
             (startswith(val, '"') || startswith(val, "'")) && (val = val[2:end])
             (endswith(val, '"') || endswith(val, "'")) && (val = val[1:end-1])
             attrs_dict[strip(parts[1])] = val

--- a/test/tests_html_attributes_rendering.jl
+++ b/test/tests_html_attributes_rendering.jl
@@ -65,6 +65,20 @@
     @test String(r.body) |> fws == """<!DOCTYPE html><html><body><div data-arg="foo bar" data-moo-hoo="123"></div></body></html>""" |> fws
   end;
 
+  @safetestset "Attribute value with `=` character" begin
+    using Genie.Renderer.Html
+    import Genie.Util: fws
+
+    r = html("""<div onclick="event = true"></div>""")
+    @test String(r.body) |> fws == """<div onclick="event = true"></div>""" |> fws
+    r = html("""<div onclick="event = true"></div>""", forceparse=true)
+    @test String(r.body) |> fws == """<!DOCTYPE html><html><body><div onclick="event = true"></div></body></html>""" |> fws
+
+    r = html("<div v-on:click='event = true'></div>")
+    @test String(r.body) |> fws == "<div v-on:click='event = true'></div>" |> fws
+    r = html("<div v-on:click='event = true'></div>", forceparse=true)
+    @test String(r.body) |> fws == """<!DOCTYPE html><html><body><div v-on:click="event = true"></div></body></html>""" |> fws
+  end;
 
   @safetestset "Single quotes" begin
     using Genie.Renderer.Html


### PR DESCRIPTION
When an attribute value contains an `=` character, the attribute is not parsed correctly and is skipped, e.g. `v-on:click="v = true"`. This PR fixes this error.