### PR TITLE
Docs MVC: Release year fails if not parsed as int

### DIFF
--- a/docs/src/tutorials/4-1--Developing_MVC_Web_Apps.md
+++ b/docs/src/tutorials/4-1--Developing_MVC_Web_Apps.md
@@ -256,7 +256,7 @@ function seed()
     m.directors = row.director
     m.actors = row.cast
     m.country = row.country
-    m.year = row.release_year
+    m.year = parse(Int, row.release_year)
     m.rating = row.rating
     m.categories = row.listed_in
     m.description = row.description


### PR DESCRIPTION
This fix seemed to have existed in Genie 4