### PR TITLE
change default value for basedir in add_fileroute

### DIFF
--- a/src/Assets.jl
+++ b/src/Assets.jl
@@ -273,7 +273,7 @@ end
 
 """
   add_fileroute(assets_config::Genie.Assets.AssetsConfig, filename::AbstractString;
-    basedir = @__DIR__,
+    basedir = pwd(),
     type::Union{Nothing, String} = nothing, 
     content_type::Union{Nothing, Symbol} = nothing,
     ext::Union{Nothing, String} = nothing, kwargs...)
@@ -297,7 +297,7 @@ Stipple.DEPS[:qdraggabletree] = draggabletree_deps
 ```
 """
 function add_fileroute(assets_config::Genie.Assets.AssetsConfig, filename::AbstractString;
-  basedir = @__DIR__,
+  basedir = pwd(),
   type::Union{Nothing, String} = nothing, 
   content_type::Union{Nothing, Symbol} = nothing,
   ext::Union{Nothing, String} = nothing, kwargs...)


### PR DESCRIPTION
The code was copied from a real world example, where @__DIR__ referred to the correct directory. After moving this to `Assets.jl` I think the best is to default it to pwd()