### PR TITLE
Fix default parameter in `Genie.Cookies.set!`

### DIFF
--- a/src/Cookies.jl
+++ b/src/Cookies.jl
@@ -71,7 +71,7 @@ Sets `value` under the `key` label on the `Cookie`.
 - `attributes::Dict`: additional cookie attributes, such as `Path` or `HttpOnly`
 - `encrypted::Bool`: if `true` the value is stored encoded
 """
-function set!(res::HTTP.Response, key::Union{String,Symbol}, value::Any, attributes::Dict{String,<:Any} = Dict(); encrypted::Bool = true) :: HTTP.Response
+function set!(res::HTTP.Response, key::Union{String,Symbol}, value::Any, attributes::Dict{String,<:Any} = Dict{String,Any}(); encrypted::Bool = true) :: HTTP.Response
   r = Genie.Headers.normalize_headers(res)
   normalized_attrs = Dict{Symbol,Any}()
   for (k,v) in attributes


### PR DESCRIPTION
When `Genie.Cookies.set!` is called 3 parameters following error occurs:
```julia
MethodError: no method matching set!(::HTTP.Messages.Response, ::Symbol, ::String, ::Dict{Any, Any})
Closest candidates are:
  set!(::HTTP.Messages.Response, ::Union{String, Symbol}, ::Any) at C:\Users\v872719\.julia\packages\Genie\mlAgh\src\Cookies.jl:74
  set!(::HTTP.Messages.Response, ::Union{String, Symbol}, ::Any, !Matched::Dict{String}; encrypted) at C:\Users\v872719\.julia\packages\Genie\mlAgh\src\Cookies.jl:74
Stacktrace:
  [1] set!(res::HTTP.Messages.Response, key::Symbol, value::String)
    @ Genie.Cookies C:\Users\v872719\.julia\packages\Genie\mlAgh\src\Cookies.jl:75
  ....
```
because of the forth parameter type restriction, the default value, `Dict()` which has type `Dict{Any,Any}`, prevents correct function call.