### PR TITLE
Docs NGINX: updated example website config file

### DIFF
--- a/docs/src/tutorials/92--Deploying_Genie_Server_Apps_with_Nginx.md
+++ b/docs/src/tutorials/92--Deploying_Genie_Server_Apps_with_Nginx.md
@@ -1,6 +1,6 @@
-# Deploying Genie apps to server with Nginx
+# Deploying Genie apps to server with NGINX
 
-This tutorial shows how to host a Julia/Genie app on with Nginx.
+This tutorial shows how to host a Julia/Genie app on with NGINX.
 
 ## Prerequisites
 
@@ -27,14 +27,14 @@ Access the server:
 ssh -i "ssh-key-for-instance.pem" user@123.123.123.123
 ```
 
-Install Julia if not present. Then make the clone:
+Install Julia if not present. Then make the clone and change to its directory:
 
 ```sh
 git clone github.com/user/MyGenieApp
-cd MyGenieAp
+cd MyGenieApp
 ```
 
-Install the app as any other Julia project:
+Install the app as any other Julia project, then exit the Julia environment:
 
 ```sh
 julia
@@ -64,14 +64,14 @@ Launch the app:
 Now the Genie app should be running on the server and be accessible at the following address: `123.123.123.123:8000`
 (if port 8000 has been open - see instance security settings). Note that you should configure the Genie app so that it
 doesn't serve the static content (see the `Settings` option `server_handle_static_file` in `config/env/prod.jl`).
-Static content should be handled by nginx. We can now detach from the `genie` screen used to launch the app (Ctl+A d).
+Static content should be handled by NGINX. We can now detach from the `genie` screen used to launch the app (Ctl+A d).
 
-## Install and configure nginx server
+## Install and configure NGINX server
 
-Nginx server will be used as a reverse proxy. It will listen requests made on port 80 (HTTP) and redirect traffic to the
+NGINX server will be used as a reverse proxy. It will listen requests made on port 80 (HTTP) and redirect traffic to the
 Genie app running on port 8000 (default Genie setting that can be changed).
 
-Nginx will also be used to serve the app static files, that is, the content under the `./public` folder.
+NGINX will also be used to serve the app static files, that is, the content under the `./public` folder.
 
 Finally, it can as well handle HTTPS requests, which will also be redirected to the Genie app listening on port 8000.
 
@@ -100,29 +100,25 @@ server {
   index         welcome.html;
 
   location / {
-      proxy_pass http://localhost:8000/;
+    try_files $uri @nginxsite;
+    expires 30d;
   }
 
-  location /css/genie {
-      proxy_pass http://localhost:8000/;
-  }
-  location /img/genie {
-      proxy_pass http://localhost:8000/;
-  }
-  location /js/genie {
-      proxy_pass http://localhost:8000/;
+  location @nginxsite {
+    proxy_pass http://localhost:8000;
   }
 }
 ```
 
-- `server_name`: refers to the web domain to be used. It can be put to an arbitrary name if the app is only to be served
-directly from the server public IP.
-- `root`: points to the `public` subfolder where the genie app was cloned.
-- `index`: refers to the site index (the landing page).
-- The various `location` following the initial proxy to the genie app are used to indicate static content folders to be
-served by nginx. These are needed when the `server_handle_static_file` is set to `false` in the Genie app settings.
+- `server_name`: refers to the web domain to be used. If the app is only to be served directly from the server public IP, an arbitrary name can be used.
+- `root`: points to the `public` subfolder where the Genie app was cloned.
+- `index`: refers to the site index (the landing page). If there is no static landing page, this line can be removed.
+- `location /`: uses `try_files` to check if static files in the designated `root` exist, so they can be served by NGINX.
+  This is needed when the `server_handle_static_file` is set to `false` in the Genie app settings. The static content now
+  gets cached, and `expires` instructs the browser to expire file cache after a certain amount of time (now it's set to 30 days).
+- `location @nginxsite`: uses `proxy_pass` to configure the proxy to redirect traffic to the address of the Genie app. 
 
-To make that config effective, it needs to be present in `sites-enabled`. The `default` config can be removed.
+To make that config effective, it needs to be present in the `sites-enabled` folder. The `default` config in this folder can be removed.
 
 ```sh
 sudo ln -s /etc/nginx/sites-available/my-genie-app /etc/nginx/sites-enabled/my-genie-app
@@ -136,10 +132,10 @@ sudo systemctl restart nginx
 
 ## Enable HTTPS
 
-To enable HTTP, a site-certificate will be needed for the domain on which the site will be served.
+To enable HTTPS, a site-certificate will be needed for the domain on which the site will be served.
 A practical approach is to use the utilities provided by [certbot](https://certbot.eff.org/).
 
-Following provided instructions for nginx on Ubuntu 20.04:
+Following provided instructions for NGINX on Ubuntu 20.04 and 22.04:
 
 ```sh
 sudo snap install core; sudo snap refresh core
@@ -147,11 +143,11 @@ sudo snap install --classic certbot
 sudo ln -s /snap/bin/certbot /usr/bin/certbot
 ```
 
-Then, using certbot utility, a certificate will be generated and appropriate modification to nginx config will be brought to handle support for HTTPS:
+Then, using certbot utility, a certificate will be generated and appropriate modification to NGINX config will be brought to handle support for HTTPS:
 
 ```sh
 sudo certbot --nginx
 ```
 
-Note that this steps will check for ownernship of the `test.com` domain mentionned in the nginx config file. For that
+Note that this steps will check for ownernship of the `test.com` domain mentioned in the NGINX config file. For that
 validation to succeed, it requires to have the `A` record for the domain set to `123.123.123.123`.


### PR DESCRIPTION
`try_files` instead of `proxy_pass` (in the example website config file) for static content, with explanation, and some other minor changes.