### PR TITLE
move `data() |> string` to fallback

### DIFF
--- a/src/renderers/Html.jl
+++ b/src/renderers/Html.jl
@@ -586,7 +586,7 @@ function html(data::ParsedHTMLString;
   Genie.Renderer.WebRenderable(body = data.data, status = status, headers = headers) |> Genie.Renderer.respond
 end
 
-function html!(data::Union{S,Vector{S}};
+function html(data::Union{S,Vector{S}};
                 status::Int = 200,
                 headers::Genie.Renderer.HTTPHeaders = Genie.Renderer.HTTPHeaders(),
                 vars...)::Genie.Renderer.HTTP.Response where {S<:AbstractString}

--- a/src/renderers/Html.jl
+++ b/src/renderers/Html.jl
@@ -566,7 +566,7 @@ function html!(data::Function;
   noparse::Bool = false,
   vars...) :: Genie.Renderer.HTTP.Response
 
-  html(data() |> string; context, status, headers, layout, forceparse, noparse, vars...)
+  html(data(); context, status, headers, layout, forceparse, noparse, vars...)
 end
 
 function html(data::HTMLString;
@@ -639,6 +639,18 @@ function html(viewfile::Genie.Renderer.FilePath;
   Genie.Renderer.WebRenderable(Genie.Renderer.render(MIME"text/html", viewfile; layout, context, vars...), status, headers) |> Genie.Renderer.respond
 end
 
+# fallback for html
+function html(data;
+  context::Module = @__MODULE__,
+  status::Int = 200,
+  headers::Genie.Renderer.HTTPHeaders = Genie.Renderer.HTTPHeaders(),
+  layout::Union{String,Nothing,Genie.Renderer.FilePath,Function} = nothing,
+  forceparse::Bool = false,
+  noparse::Bool = false,
+  vars...) :: Genie.Renderer.HTTP.Response
+
+  html(data |> string; context, status, headers, layout, forceparse, noparse, vars...)
+end
 
 """
     safe_attr(attr) :: String

--- a/src/renderers/Html.jl
+++ b/src/renderers/Html.jl
@@ -399,9 +399,9 @@ function parseview(data::S; partial = false, context::Module = @__MODULE__, _...
 
   if f_stale || ! isdefined(context, func_name)
     if f_stale
-      Genie.Renderer.build_module(string_to_julia(data, partial = partial), path, mod_name)
+      Genie.Renderer.build_module(string_to_julia(data, partial = partial, f_name = func_name), path, mod_name)
     end
-
+    
     return Base.include(context, joinpath(Genie.config.path_build, Genie.Renderer.BUILD_NAME, mod_name))
   end
 

--- a/src/renderers/Html.jl
+++ b/src/renderers/Html.jl
@@ -548,8 +548,6 @@ function html(data::String;
     layout
   end
 
-  isa(data, Function) && (data = data() |> string)
-
   if (occursin(raw"$", data) || occursin(EMBED_JULIA_OPEN_TAG, data) || layout !== nothing || forceparse) && ! noparse
     html(HTMLString(data); context = context, status = status, headers = headers, layout = layout, vars...)
   else


### PR DESCRIPTION
Currently, no typecheck is done after calling `data()` when`data` is a function.
I propose to first call `html(data())` without piping it through string and move the string call to a fallback.
That speeds up page generation by two order of magnitudes.

Example code:

```julia
using Stipple, Stipple.ReactiveTools
using StippleUI

@handlers begin
     @in sample_num = 7
     @onchange sample_num begin
          @info "Hi", isready, sample_num
     end
 end
 
function ui()
     [
          row(cell(slider(1:1:10,:sample_num,label=true)))
     ]
end

@page("/", ui)

@time Genie.Router._routes[:get].action()
```
EDIT: updated `ui()`
EDIT2: reverted `ui()` to what it was before. This works now after the second patch