### PR TITLE
remove fallback for html

### DIFF
--- a/src/renderers/Html.jl
+++ b/src/renderers/Html.jl
@@ -637,18 +637,6 @@ function html(viewfile::Genie.Renderer.FilePath;
   Genie.Renderer.WebRenderable(Genie.Renderer.render(MIME"text/html", viewfile; layout, context, vars...), status, headers) |> Genie.Renderer.respond
 end
 
-# fallback for html
-function html(data;
-  context::Module = @__MODULE__,
-  status::Int = 200,
-  headers::Genie.Renderer.HTTPHeaders = Genie.Renderer.HTTPHeaders(),
-  layout::Union{String,Nothing,Genie.Renderer.FilePath,Function} = nothing,
-  forceparse::Bool = false,
-  noparse::Bool = false,
-  vars...) :: Genie.Renderer.HTTP.Response
-
-  html(data |> string; context, status, headers, layout, forceparse, noparse, vars...)
-end
 
 """
     safe_attr(attr) :: String

--- a/test/tests_content_negotiation.jl
+++ b/test/tests_content_negotiation.jl
@@ -10,21 +10,13 @@
 
       server = up(port; open_browser = false)
 
-      response = try
-        HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "text/html"])
-      catch ex
-        ex.response
-      end
+      response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "text/html"], status_exception = false)
 
       @test response.status == 404
       @test occursin("Sorry, we can not find", String(response.body)) == true
       @test Dict(response.headers)["Content-Type"] == "text/html"
 
-      response = try
-        HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["COnTeNT-TyPe" => "text/html"])
-      catch ex
-        ex.response
-      end
+      response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["COnTeNT-TyPe" => "text/html"], status_exception = false)
 
       @test response.status == 404
       @test occursin("Sorry, we can not find", String(response.body)) == true
@@ -45,21 +37,13 @@
 
       server = up(port; open_browser = false)
 
-      response = try
-        HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/html"])
-      catch ex
-        ex.response
-      end
+      response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/html"], status_exception = false)
 
       @test response.status == 404
       @test occursin("Sorry, we can not find", String(response.body)) == true
       @test Dict(response.headers)["Content-Type"] == "text/html"
 
-      response = try
-        HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["AcCePt" => "text/html"])
-      catch ex
-        ex.response
-      end
+      response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["AcCePt" => "text/html"], status_exception = false)
 
       @test response.status == 404
       @test occursin("Sorry, we can not find", String(response.body)) == true
@@ -80,21 +64,13 @@
 
       server = up(port; open_browser = false)
 
-      response = try
-        HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "application/json"])
-      catch ex
-        ex.response
-      end
+      response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "application/json"], status_exception = false)
 
       @test response.status == 404
       @test occursin("404 Not Found", String(response.body)) == true
       @test Dict(response.headers)["Content-Type"] == "application/json; charset=utf-8"
 
-      response = try
-        HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["CoNtEnt-TyPe" => "application/json"])
-      catch ex
-        ex.response
-      end
+      response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["CoNtEnt-TyPe" => "application/json"], status_exception = false)
 
       @test response.status == 404
       @test occursin("404 Not Found", String(response.body)) == true
@@ -115,21 +91,13 @@
 
       server = up(port; open_browser = false)
 
-      response = try
-        HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "application/json"])
-      catch ex
-        ex.response
-      end
+      response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "application/json"], status_exception = false)
 
       @test response.status == 404
       @test occursin("404 Not Found", String(response.body)) == true
       @test Dict(response.headers)["Content-Type"] == "application/json; charset=utf-8"
 
-      response = try
-        HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["acCepT" => "application/json"])
-      catch ex
-        ex.response
-      end
+      response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["acCepT" => "application/json"], status_exception = false)
 
       @test response.status == 404
       @test occursin("404 Not Found", String(response.body)) == true
@@ -150,21 +118,13 @@
 
       server = up(port; open_browser = false)
 
-      response = try
-        HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "text/plain"])
-      catch ex
-        ex.response
-      end
+      response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "text/plain"], status_exception = false)
 
       @test response.status == 404
       @test occursin("404 Not Found", String(response.body)) == true
       @test Dict(response.headers)["Content-Type"] == "text/plain"
 
-      response = try
-        HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["conTeNT-tYPE" => "text/plain"])
-      catch ex
-        ex.response
-      end
+      response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["conTeNT-tYPE" => "text/plain"], status_exception = false)
 
       @test response.status == 404
       @test occursin("404 Not Found", String(response.body)) == true
@@ -186,21 +146,13 @@
 
     server = up(port; open_browser = false)
 
-    response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "text/csv"])
-    catch ex
-      ex.response
-    end
+    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "text/csv"], status_exception = false)
 
     @test response.status == 404
     @test occursin("404 Not Found", String(response.body)) == true
     @test Dict(response.headers)["Content-Type"] == "text/csv"
 
-    response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["conTeNT-tYPE" => "text/csv"])
-    catch ex
-      ex.response
-    end
+    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["conTeNT-tYPE" => "text/csv"], status_exception = false)
 
     @test response.status == 404
     @test occursin("404 Not Found", String(response.body)) == true
@@ -221,21 +173,13 @@
 
     server = up(port; open_browser = false)
 
-    response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/csv"])
-    catch ex
-      ex.response
-    end
+    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/csv"], status_exception = false)
 
     @test response.status == 404
     @test occursin("404 Not Found", String(response.body)) == true
     @test Dict(response.headers)["Content-Type"] == "text/csv"
 
-    response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["accEPT" => "text/csv"])
-    catch ex
-      ex.response
-    end
+    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["accEPT" => "text/csv"], status_exception = false)
 
     @test response.status == 404
     @test occursin("404 Not Found", String(response.body)) == true
@@ -256,11 +200,7 @@
 
     server = up(port; open_browser = false)
 
-    response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "text/csv"])
-    catch ex
-      ex.response
-    end
+    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "text/csv"], status_exception = false)
 
     @test response.status == 404
     @test occursin("404 Not Found", String(response.body)) == true
@@ -270,21 +210,13 @@
       HTTP.Response(401, ["Content-Type" => "text/csv"], body = "Search CSV and you shall find")
     end
 
-    response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["conTeNT-tYPE" => "text/csv"])
-    catch ex
-      ex.response
-    end
+    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["conTeNT-tYPE" => "text/csv"], status_exception = false)
 
     @test response.status == 401
     @test occursin("Search CSV and you shall find", String(response.body)) == true
     @test Dict(response.headers)["Content-Type"] == "text/csv"
 
-    response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["accept" => "text/csv"])
-    catch ex
-      ex.response
-    end
+    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["accept" => "text/csv"], status_exception = false)
 
     @test response.status == 401
     @test occursin("Search CSV and you shall find", String(response.body)) == true
@@ -305,11 +237,7 @@
 
     server = up(port; open_browser = false)
 
-    response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "application/json"])
-    catch ex
-      ex.response
-    end
+    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "application/json"], status_exception = false)
 
     @test response.status == 404
     @test occursin("404 Not Found", String(response.body)) == true
@@ -319,21 +247,13 @@
       HTTP.Response(401, ["Content-Type" => "application/json"], body = "Search CSV and you shall find")
     end
 
-    response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["conTeNT-tYPE" => "application/json"])
-    catch ex
-      ex.response
-    end
+    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["conTeNT-tYPE" => "application/json"], status_exception = false)
 
     @test response.status == 401
     @test occursin("Search CSV and you shall find", String(response.body)) == true
     @test Dict(response.headers)["Content-Type"] == "application/json"
 
-    response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["accept" => "application/json"])
-    catch ex
-      ex.response
-    end
+    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["accept" => "application/json"], status_exception = false)
 
     @test response.status == 401
     @test occursin("Search CSV and you shall find", String(response.body)) == true
@@ -354,59 +274,31 @@
 
     server = up(port; open_browser = false)
 
-    response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/html, text/plain, application/json, text/csv"])
-    catch ex
-      ex.response
-    end
+    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/html, text/plain, application/json, text/csv"], status_exception = false)
 
     @test Dict(response.headers)["Content-Type"] == "text/html"
 
-    response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/plain, application/json, text/csv, text/html"])
-    catch ex
-      ex.response
-    end
+    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/plain, application/json, text/csv, text/html"], status_exception = false)
 
     @test Dict(response.headers)["Content-Type"] == "text/plain"
 
-    response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "application/json, text/csv, text/html, text/plain"])
-    catch ex
-      ex.response
-    end
+    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "application/json, text/csv, text/html, text/plain"], status_exception = false)
 
     @test Dict(response.headers)["Content-Type"] == "application/json"
 
-    response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/csv, text/html, text/plain, application/json"])
-    catch ex
-      ex.response
-    end
+    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/csv, text/html, text/plain, application/json"], status_exception = false)
 
     @test Dict(response.headers)["Content-Type"] == "text/html"
 
-    response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/csv, text/plain, application/json, text/html"])
-    catch ex
-      ex.response
-    end
+    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/csv, text/plain, application/json, text/html"], status_exception = false)
 
     @test Dict(response.headers)["Content-Type"] == "text/plain"
 
-    response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/csv, application/json, text/html, text/plain"])
-    catch ex
-      ex.response
-    end
+    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/csv, application/json, text/html, text/plain"], status_exception = false)
 
     @test Dict(response.headers)["Content-Type"] == "application/json"
 
-    response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/csv"])
-    catch ex
-      ex.response
-    end
+    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/csv"], status_exception = false)
 
     @test Dict(response.headers)["Content-Type"] == "text/csv"
 


### PR DESCRIPTION
The fallback was already covered by the general fallbacks from `register_normal_element()` but the desired output type is ParsedHTMLString