### PR TITLE
include all disconnected clients in disconnected_clients()

### DIFF
--- a/src/WebChannels.jl
+++ b/src/WebChannels.jl
@@ -70,12 +70,12 @@ function disconnected_clients(channel::ChannelName) :: Vector{ChannelClient}
   clients
 end
 function disconnected_clients() :: Vector{ChannelClient}
-  clients = ChannelClient[]
-  for ch in channels()
-    clients = vcat(clients, disconnected_clients(ch))
+  channel_clients = ChannelClient[]
+  for channel_client in clients()
+    HTTP.WebSockets.isclosed(channel_client.client) && push!(channel_clients, channel_client)
   end
 
-  clients
+  channel_clients
 end
 
 


### PR DESCRIPTION
Currently `disconnected_clients()` only loops over all channels and relies on that all channels are properly registered in SUBSCRIPTIONS.
That way, falsely generated clients that never subscribed are missed and start populating the memory.
Looping over all `clients()` solves this memory issue.