### PR TITLE
html docs fix

### DIFF
--- a/src/renderers/Html.jl
+++ b/src/renderers/Html.jl
@@ -622,8 +622,8 @@ end
 Parses and renders the HTML `viewfile`, optionally rendering it within the `layout` file. Valid file format is `.html.jl`.
 
 # Arguments
-- `viewfile::FilePath`: filesystem path to the view file as a `Renderer.FilePath`, ie `Renderer.FilePath("/path/to/file.html.jl")`
-- `layout::FilePath`: filesystem path to the layout file as a `Renderer.FilePath`, ie `Renderer.FilePath("/path/to/file.html.jl")`
+- `viewfile::FilePath`: filesystem path to the view file as a `Renderer.FilePath`, ie `Renderer.filepath("/path/to/file.html.jl")` or `path"/path/to/file.html.jl"`
+- `layout::FilePath`: filesystem path to the layout file as a `Renderer.FilePath`, ie `Renderer.FilePath("/path/to/file.html.jl")` or `path"/path/to/file.html.jl"`
 - `context::Module`: the module in which the variables are evaluated (in order to provide the scope for vars). Usually the controller.
 - `status::Int`: status code of the response
 - `headers::HTTPHeaders`: HTTP response headers


### PR DESCRIPTION
Just a quick typo correction to html docs that cause me some confusion (FilePath is only the type, doesn't has constructors, filepath is the "constructor").