### PR TITLE
Fix the `up` command ignoring the `host` param - Genie uses a wrong hostname when listening for socket.

### DIFF
--- a/src/Server.jl
+++ b/src/Server.jl
@@ -153,8 +153,8 @@ function up(port::Int,
   new_server
 end
 
-function up(; port = Genie.config.server_port, ws_port = Genie.config.websockets_port, kwargs...) :: ServersCollection
-  up(port; ws_port = ws_port, kwargs...)
+function up(; port = Genie.config.server_port, ws_port = Genie.config.websockets_port, host = Genie.config.server_host, kwargs...) :: ServersCollection
+  up(port, host; ws_port = ws_port, kwargs...)
 end
 
 


### PR DESCRIPTION


Genie's `up` with kwargs is ignoring the `host` when starting the server. The configuration switches to the default `127.0.0.1`.

### Wrong behavior
The `host` kwargs parameter is ignored.

Example (Before applying the fix)
```
julia> up(;host="0.0.0.0")
┌ Info:
└ Web Server starting at http://127.0.0.1:8000
[ Info: Listening on: 127.0.0.1:8000, thread id: 1
Genie.Server.ServersCollection(Task (runnable) @0x00000155919a7460, nothing)
```
### What was fixed

1. The `host` keyword with a default value has been added to the `up(;...)` function. 
2. The call to `up(port, host; ...)` has been corrected not to override the `host` parameter value. 

### Behavior after patch
```
julia> up(;host="0.0.0.0")
┌ Info:
└ Web Server starting at http://0.0.0.0:8000
[ Info: Listening on: 0.0.0.0:8000, thread id: 1
Genie.Server.ServersCollection(Task (runnable) @0x000001559190a2f0, nothing)
```

### Justification 
This bug makes life hard for people trying to run Genie with the `up(;host="0.0.0.0")` in a Docker container where Genie is running but connection is not possible (as the default `127.0.0.1`) gets blocked. 
Should be please merged ASAP as this bug supports one of  those "Julia does not work with Docker" stories...

### Credits: 
the bug was discovered by @sebkaz

 