### PR TITLE
Fix Geine v4/julia v1.8+ compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -50,7 +50,7 @@ Reexport = "0.2, 1"
 Revise = "2, 3"
 VersionCheck = "0.1, 0.2, 1"
 YAML = "0.4"
-julia = "~1.6, ~1.7"
+julia = "1.6"
 
 [extras]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -44,12 +44,6 @@
   </p>
 </div>
 
-<h2>
-  Important: Genie v4 is not compatible with Julia version 1.8 and up. For Julia 1.8 and up support, please use Genie 5.
-  If you have applications developed with Genie v4, please upgrade them to Genie 5, by following the migration guide
-  provided in the Genie docs.
-</h2>
-
 <p style="font-family:verdana;font-size:80%;margin-bottom:4%" align="center">
 <u>Julia data dashboards powered by Genie</u>
 </p>

--- a/src/Generator.jl
+++ b/src/Generator.jl
@@ -366,6 +366,7 @@ function write_app_custom_files(path::String, app_path::String) :: Nothing
     (pwd() != @__DIR__) && cd(@__DIR__) # allow starting app from bin/ dir
 
     using $(moduleinfo[1])
+    isdefined(Base, :modules_warned_for) &&
     push!(Base.modules_warned_for, Base.PkgId($(moduleinfo[1])))
     $(moduleinfo[1]).main()
     """)


### PR DESCRIPTION
The fix is incredibly simple: if the julia internals for hinting about which modules should get warnings are missing, don't provide those hints.

I also removed the warnings telling people and Pkg about this incompatibility (a separate PR is needed to remove the warning in the readme on the master branch). When possible, it's better to fix something than to warn folks about it, even if Genie v4 is old.

- fix genie v4 on julia 1.8+
- revert 8686f9f5 "limit julia compat for v4"
- remove incompatibility warning