### PR TITLE
Run CI on the latest version of Julia instead of 1.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
       matrix:
         version:
           - '1.6'
-          - '1.7'
           - '1.8'
+          - '1' # expands to the latest stable releaase of julia
           - 'nightly'
         os:
           - ubuntu-latest


### PR DESCRIPTION
It's also an option to keep CI for 1.7, but that release is neither the stable release, nor the second most recent stable release, nor the LTS release, so I think it is okay to drop it.