### PR TITLE
Bump to 4.20.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Genie"
 uuid = "c43c736e-a2d1-11e8-161f-af95117fbd1e"
 authors = ["Adrian Salceanu <e@essenciary.com>"]
-version = "4.20.1"
+version = "4.20.2"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"


### PR DESCRIPTION
I think fixing an error on 1.8/1.9 warrants a patch release. Ideally, this release would have been registered before merging #646, but the exact timing doesn't matter too much.