### PR TITLE
fix #656

### DIFF
--- a/src/Generator.jl
+++ b/src/Generator.jl
@@ -617,7 +617,6 @@ You can add support for additional databases anytime later. ")
     @warn "You need to edit the database configuration file at db/connection.yml to set your database connection info."
   end
 
-  Pkg.activate(".")
   testmode ? Pkg.develop("SearchLight$adapter", io = devnull) : Pkg.add("SearchLight$adapter", io = devnull)
 
   adapter


### PR DESCRIPTION
fix #656 
`Pkg.activate` created a new environment outside the template and added the `SearchLight` adapter to it. I removed the statement and no `*.toml` files were created after that. Also the `SearchLight` adapter were added in the inner `Project.toml` 