### PR TITLE
refactor revivers

### DIFF
--- a/assets/js/channels.js
+++ b/assets/js/channels.js
@@ -118,30 +118,33 @@ function newSocketConnection(host = Genie.Settings.websockets_exposed_host) {
     return ws
 }
 
-Genie.pipeRevivers = (revivers) => (key, value) => revivers.reduce((v, f) => f(key, v), value);
-
-Genie.rebuildReviver = function() {
-    Genie.reviver = Genie.pipeRevivers(Genie.revivers)
-}
-
-Genie.addReviver = function(reviver) {
-    Genie.revivers.push(reviver)
-    Genie.reviver = Genie.pipeRevivers(Genie.revivers)
-}
-
-Genie.revive_undefined = function(key, value) {
-    if (value == '__undefined__') {
-        return undefined;
-    } else {
-        return value;
-    }
-}
-
-Genie.revivers = [Genie.revive_undefined]
-Genie.rebuildReviver()
-
 Genie.WebChannels.initialize();
 Genie.WebChannels.socket = newSocketConnection();
+
+// --------------- Revivers ---------------
+
+Genie.Revivers = {};
+Genie.Revivers.pipeRevivers = (revivers) => (key, value) => revivers.reduce((v, f) => f(key, v), value);
+
+Genie.Revivers.rebuildReviver = function() {
+  Genie.Revivers.reviver = Genie.Revivers.pipeRevivers(Genie.Revivers.revivers)
+}
+
+Genie.Revivers.addReviver = function(reviver) {
+  Genie.Revivers.revivers.push(reviver)
+  Genie.Revivers.rebuildReviver()
+}
+
+Genie.Revivers.revive_undefined = function(key, value) {
+  if (value == '__undefined__') {
+    return undefined;
+  } else {
+    return value;
+  }
+}
+
+Genie.Revivers.revivers = [Genie.Revivers.revive_undefined]
+Genie.Revivers.rebuildReviver()
 
 window.addEventListener('beforeunload', _ => {
   if (isDev()) {
@@ -171,7 +174,7 @@ Genie.WebChannels.messageHandlers.push(event => {
     }
 
     if (ed.startsWith('{') && ed.endsWith('}')) {
-      window.parse_payload(JSON.parse(ed, Genie.reviver));
+      window.parse_payload(JSON.parse(ed, Genie.Revivers.reviver));
     } else if (ed.startsWith(Genie.Settings.webchannels_eval_command)) {
       return Function('"use strict";return (' + ed.substring(Genie.Settings.webchannels_eval_command.length).trim() + ')')();
     } else if (ed == 'Subscription: OK') {

--- a/assets/js/channels.js
+++ b/assets/js/channels.js
@@ -181,7 +181,7 @@ Genie.WebChannels.messageHandlers.push(event => {
     }
   } catch (ex) {
     console.error(ex);
-    console.error(ed);
+    console.error(event.data);
   }
 });
 

--- a/assets/js/webthreads.js
+++ b/assets/js/webthreads.js
@@ -137,27 +137,28 @@ function push(body, headers = {}) {
 }
 
 
-Genie.pipeRevivers = (revivers) => (key, value) => revivers.reduce((v, f) => f(key, v), value);
+Genie.Revivers = {};
+Genie.Revivers.pipeRevivers = (revivers) => (key, value) => revivers.reduce((v, f) => f(key, v), value);
 
-Genie.rebuildReviver = function() {
-    Genie.reviver = Genie.pipeRevivers(Genie.revivers)
+Genie.Revivers.rebuildReviver = function() {
+  Genie.Revivers.reviver = Genie.Revivers.pipeRevivers(Genie.Revivers.revivers)
 }
 
-Genie.addReviver = function(reviver) {
-    Genie.revivers.push(reviver)
-    Genie.reviver = Genie.pipeRevivers(Genie.revivers)
+Genie.Revivers.addReviver = function(reviver) {
+  Genie.Revivers.revivers.push(reviver)
+  Genie.Revivers.rebuildReviver()
 }
 
-Genie.revive_undefined = function(key, value) {
-    if (value == '__undefined__') {
-        return undefined;
-    } else {
-        return value;
-    }
+Genie.Revivers.revive_undefined = function(key, value) {
+  if (value == '__undefined__') {
+    return undefined;
+  } else {
+    return value;
+  }
 }
 
-Genie.revivers = [Genie.revive_undefined]
-Genie.rebuildReviver()
+Genie.Revivers.revivers = [Genie.Revivers.revive_undefined]
+Genie.Revivers.rebuildReviver()
 
 Genie.WebChannels.processingHandlers.push(function(json_data){
   window.parse_payload(json_data);
@@ -189,7 +190,7 @@ function processMessage(message) {
   } else if (message == 'Subscription: OK') {
     window.subscription_ready();
   } else if (message.startsWith('{') && message.endsWith('}')) {
-    window.parse_payload(JSON.parse(message, Genie.reviver));
+    window.parse_payload(JSON.parse(message, Genie.Revivers.reviver));
   } else {
     window.process_payload(message);
   }


### PR DESCRIPTION
I refactored the Genie's reviver for easier implementation of user-defined revivers.
There's a respective hh-revivers branch on Stipple.jl

I define `Genie.revivers` as an array which holds all revivers and `Genie.revive()` which is the resulting reviver function.
After adding a reviver function to the array calling `rebuildReviver()` will build `Genie.revive()`.

This is all covered in the javascript function `Genie.addReviver(f)`

This makes the construction of a StippleMathjs.jl (see https://github.com/GenieFramework/Stipple.jl/issues/235) very easy.

-------------------

This solution goes was greatly inspired by https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse