### PR TITLE
do not perform timestamp transform for log messages that are not logged

### DIFF
--- a/src/Logger.jl
+++ b/src/Logger.jl
@@ -54,7 +54,7 @@ function initialize_logging(; log_name = default_log_name())
     end
   )
 
-  LoggingExtras.TeeLogger(LoggingExtras.MinLevelLogger(logger, Genie.config.log_level)) |> timestamp_logger |> global_logger
+  LoggingExtras.MinLevelLogger(timestamp_logger(logger, Genie.config.log_level)) |> global_logger
 
   nothing
 end

--- a/src/Logger.jl
+++ b/src/Logger.jl
@@ -54,7 +54,7 @@ function initialize_logging(; log_name = default_log_name())
     end
   )
 
-  LoggingExtras.MinLevelLogger(timestamp_logger(logger, Genie.config.log_level)) |> global_logger
+  LoggingExtras.MinLevelLogger(timestamp_logger(logger), Genie.config.log_level) |> global_logger
 
   nothing
 end


### PR DESCRIPTION
Should fix e.g. #673 

The problem is that we also processed debug messages with the `timestamp_logger` and Arrow.jl has many of them.

This way we apply `LoggingExtras.MinLevelLogger` to any log message first and thus only further messages that are relevant w.r.t. `Genie.config.log_level`.