### PR TITLE
change ServersCollection to contain `HTTP.Server`s instead of tasks

### DIFF
--- a/src/Server.jl
+++ b/src/Server.jl
@@ -153,6 +153,8 @@ function up(port::Int,
       nothing
     finally
       close(listener)
+      # close the corresponding websocket server
+      new_server.websockets !== nothing && isopen(new_server.websockets) && close(new_server.websockets)
     end
   end
 

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -149,6 +149,8 @@ function up(port::Int,
   if !async && !isnothing(listener)
     try
       wait(listener)
+    catch
+      nothing
     finally
       close(listener)
     end

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -7,7 +7,7 @@ using HTTP, Sockets, HTTP.WebSockets
 import Millboard, Distributed, Logging
 import Genie
 import Distributed
-import HTTP.Servers.Listener
+import HTTP.Servers: Listener, forceclose
 
 
 """
@@ -253,18 +253,19 @@ end
 Shuts down the servers optionally indicating which of the `webserver` and `websockets` servers to be stopped.
 It does not remove the servers from the `SERVERS` collection. Returns the collection.
 """
-function down(; webserver::Bool = true, websockets::Bool = true) :: Vector{ServersCollection}
+function down(; webserver::Bool = true, websockets::Bool = true, force::Bool = true) :: Vector{ServersCollection}
   for i in 1:length(SERVERS)
-    down(SERVERS[i]; webserver, websockets)
+    down(SERVERS[i]; webserver, websockets, force)
   end
 
   SERVERS
 end
 
 
-function down(server::ServersCollection; webserver::Bool = true, websockets::Bool = true) :: ServersCollection
-  webserver && !isnothing(server.webserver) && isopen(server.webserver) && close(server.webserver)
-  websockets && !isnothing(server.websockets) && isopen(server.websockets) && close(server.websockets)
+function down(server::ServersCollection; webserver::Bool = true, websockets::Bool = true, force::Bool = true) :: ServersCollection
+  close_cmd = force ? forceclose : close
+  webserver && !isnothing(server.webserver) && isopen(server.webserver) && close_cmd(server.webserver)
+  websockets && !isnothing(server.websockets) && isopen(server.websockets) && close_cmd(server.websockets)
 
   server
 end

--- a/test/tests_AppServer.jl
+++ b/test/tests_AppServer.jl
@@ -8,24 +8,24 @@
     empty!(Genie.Server.SERVERS)
 
     servers = Genie.Server.up()
-    @test servers.webserver.state == :runnable
+    @test isopen(servers.webserver)
 
     servers = Genie.Server.down(servers)
     sleep(1)
-    @test servers.webserver.state == :failed
-    @test Genie.Server.SERVERS[1].webserver.state == :failed
+    @test !isopen(servers.webserver)
+    @test !isopen(Genie.Server.SERVERS[1].webserver)
 
     servers = Genie.Server.down!()
     empty!(Genie.Server.SERVERS)
 
     servers = Genie.Server.up(; open_browser = false)
     Genie.Server.down(servers; webserver = false)
-    @test servers.webserver.state == :runnable
+    @test isopen(servers.webserver)
 
     servers = Genie.Server.down(servers; webserver = true)
     sleep(1)
-    @test servers.webserver.state == :failed
-    @test Genie.Server.SERVERS[1].webserver.state == :failed
+    @test !isopen(servers.webserver)
+    @test !isopen(Genie.Server.SERVERS[1].webserver)
 
     servers = nothing
   end;


### PR DESCRIPTION
Currently `Genie.Server.ServersCollection` stores the tasks of webserver and websockets.
In case of async servers, the only way of terminating the servers is to throw an InterruptException to the tasks, which is done when `down()` is called.

Here, I propose to always call the non-blocking variants of the server command (`listen!` instead of `listen`) and to store the result instead. This way it is possible to gracefully shutdown a server by calling `close()` on it.

Moreover, and this is the origin of this PR, there is no trailing task from calling `Base.throwto()` which currently blocks precompilation of Stipple, when a Demo app is included via PrecompileTools.

With this PR in place and a short precompilation section in Stipple, the startup time of a Stipple app shrinks from 23 seconds downto 16 seconds.

As `up()` and `down()` return Genie.Server.ServersCollection or Vectors of it, this is probably a breaking change.

Checking the state of the server is no longer done by asking for `server.state == :runnable` but by `isopen(server)`