### PR TITLE
Hh addfileroute

### DIFF
--- a/src/Assets.jl
+++ b/src/Assets.jl
@@ -328,7 +328,7 @@ function add_fileroute(assets_config::Genie.Assets.AssetsConfig, filename::Abstr
   basedir = pwd(),
   type::Union{Nothing, String} = nothing,
   content_type::Union{Nothing, Symbol} = nothing,
-  ext::Union{Nothing, String} = nothing, kwargs...)
+  ext::Union{Nothing, String} = nothing, named::Union{Symbol, Nothing} = nothing, kwargs...)
 
   file, ex = splitext(filename)
   ext = isnothing(ext) ? ex : ext
@@ -345,7 +345,7 @@ function add_fileroute(assets_config::Genie.Assets.AssetsConfig, filename::Abstr
     Symbol("*.*")
   end : content_type
 
-  Genie.Router.route(Genie.Assets.asset_path(assets_config, type; file, ext, kwargs...)) do
+  Genie.Router.route(Genie.Assets.asset_path(assets_config, type; file, ext, kwargs...); named) do
     Genie.Renderer.WebRenderable(
       Genie.Assets.embedded(Genie.Assets.asset_file(cwd=basedir; type, file)),
     content_type) |> Genie.Renderer.respond

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -153,6 +153,8 @@ function up(port::Int,
       nothing
     finally
       close(listener)
+      # close the corresponding websocket server
+      new_server.websockets !== nothing && isopen(new_server.websockets) && close(new_server.websockets)
     end
   end
 

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -149,6 +149,8 @@ function up(port::Int,
   if !async && !isnothing(listener)
     try
       wait(listener)
+    catch
+      nothing
     finally
       close(listener)
     end

--- a/src/Server.jl
+++ b/src/Server.jl
@@ -7,7 +7,7 @@ using HTTP, Sockets, HTTP.WebSockets
 import Millboard, Distributed, Logging
 import Genie
 import Distributed
-import HTTP.Servers.Listener
+import HTTP.Servers: Listener, forceclose
 
 
 """
@@ -253,18 +253,19 @@ end
 Shuts down the servers optionally indicating which of the `webserver` and `websockets` servers to be stopped.
 It does not remove the servers from the `SERVERS` collection. Returns the collection.
 """
-function down(; webserver::Bool = true, websockets::Bool = true) :: Vector{ServersCollection}
+function down(; webserver::Bool = true, websockets::Bool = true, force::Bool = true) :: Vector{ServersCollection}
   for i in 1:length(SERVERS)
-    down(SERVERS[i]; webserver, websockets)
+    down(SERVERS[i]; webserver, websockets, force)
   end
 
   SERVERS
 end
 
 
-function down(server::ServersCollection; webserver::Bool = true, websockets::Bool = true) :: ServersCollection
-  webserver && !isnothing(server.webserver) && isopen(server.webserver) && close(server.webserver)
-  websockets && !isnothing(server.websockets) && isopen(server.websockets) && close(server.websockets)
+function down(server::ServersCollection; webserver::Bool = true, websockets::Bool = true, force::Bool = true) :: ServersCollection
+  close_cmd = force ? forceclose : close
+  webserver && !isnothing(server.webserver) && isopen(server.webserver) && close_cmd(server.webserver)
+  websockets && !isnothing(server.websockets) && isopen(server.websockets) && close_cmd(server.websockets)
 
   server
 end

--- a/test/tests_AppServer.jl
+++ b/test/tests_AppServer.jl
@@ -8,24 +8,24 @@
     empty!(Genie.Server.SERVERS)
 
     servers = Genie.Server.up()
-    @test servers.webserver.state == :runnable
+    @test isopen(servers.webserver)
 
     servers = Genie.Server.down(servers)
     sleep(1)
-    @test servers.webserver.state == :failed
-    @test Genie.Server.SERVERS[1].webserver.state == :failed
+    @test !isopen(servers.webserver)
+    @test !isopen(Genie.Server.SERVERS[1].webserver)
 
     servers = Genie.Server.down!()
     empty!(Genie.Server.SERVERS)
 
     servers = Genie.Server.up(; open_browser = false)
     Genie.Server.down(servers; webserver = false)
-    @test servers.webserver.state == :runnable
+    @test isopen(servers.webserver)
 
     servers = Genie.Server.down(servers; webserver = true)
     sleep(1)
-    @test servers.webserver.state == :failed
-    @test Genie.Server.SERVERS[1].webserver.state == :failed
+    @test !isopen(servers.webserver)
+    @test !isopen(Genie.Server.SERVERS[1].webserver)
 
     servers = nothing
   end;


### PR DESCRIPTION
I propose to add `:named` to the kwargs of for `add_fileroute`.
It's non-breaking and would allow for cleaner definition sections in addons, e.g. in StipplePlotly.

