### PR TITLE
export `@using` and add docstring

### DIFF
--- a/src/Genie.jl
+++ b/src/Genie.jl
@@ -47,6 +47,7 @@ include("Logger.jl")
 
 export up, down
 @reexport using .Router
+@reexport using .Loader
 
 const assets_config = Genie.Assets.assets_config
 


### PR DESCRIPTION
Loading of modules is currently done via `Revise.includet()`
This is slow as it doesn't allow for precompilation.

My proposal is to replace this procedure by `using` statements when possible.

To make that procedure easier I have written a handy `@using` macro that does the following.

Here's the doc string:

 `@using(package_path)`

macro to simplify loading of modules that are not located in the LOAD_PATH

`package_path` can be
- a path to a directory containing a module file of the same name
    e.g 'models/MyApp' to load 'models/MyApp/MyApp.jl'
- a path to a module (without extension '.jl')
    e.g. 'models/MyApp' to load models/MyApp.jl'
- a path to a package directory containing a 'src' directory and module file therein
    e.g. 'models/MyApp' to load 'models/MyApp/src/MyApp.jl'

### Examples

```julia
@using models/MyApp

@using StippleDemos/Vue3/Calendars
```
or explicitly
```julia
@using StippleDemos/Vue3/Calendars/Calendars
```
Note, directories containing special characters like colon (`':'`) or space (`' '`)
need to be escaped by double quotes.
```julia
@using "C:/Program Files/Julia/models/Calendars"

# or
@using "C:/Program Files"/Julia/models/Calendars
```

Caveat: Due to precompilation it is not possible to supply variables to the macro.
Calls need to supply explicit paths.
