### PR TITLE
fix segfault for julia 1.10

### DIFF
--- a/test/_disabled_/tests_Sessions.jl
+++ b/test/_disabled_/tests_Sessions.jl
@@ -16,9 +16,10 @@
 #     end
 
 #     server = up()
+#     client = HTTP.Client()
 
 #     # TODO: extend to use the cookie and increment the count
-#     response = HTTP.get("http://$(Genie.config.server_host):$(Genie.config.server_port)/home")
+#     response = HTTP.get(client, "http://$(Genie.config.server_host):$(Genie.config.server_port)/home")
 #     @test response.body |> String == "1"
 
 #     down()

--- a/test/tests_arguments_parsing.jl
+++ b/test/tests_arguments_parsing.jl
@@ -14,9 +14,10 @@
   port = rand(8500:8900)
 
   server = up(port; open_browser = false)
+  client = HTTP.Client()
 
-  response = HTTP.get("http://localhost:$port/getparams/foo/23.43/18/2019-02-15")
-
+  response = HTTP.get(client, "http://localhost:$port/getparams/foo/23.43/18/2019-02-15")
+  
   @test response.status == 200
   @test String(response.body) == "s = foo / f = 23.43 / i = 18 / 2019-02-15"
 

--- a/test/tests_content_negotiation.jl
+++ b/test/tests_content_negotiation.jl
@@ -10,13 +10,14 @@
 
       server = up(port; open_browser = false)
 
-      response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "text/html"], status_exception = false)
+      client = HTTP.Client()
+      response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "text/html"], status_exception = false)
 
       @test response.status == 404
       @test occursin("Sorry, we can not find", String(response.body)) == true
       @test Dict(response.headers)["Content-Type"] == "text/html"
 
-      response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["COnTeNT-TyPe" => "text/html"], status_exception = false)
+      response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["COnTeNT-TyPe" => "text/html"], status_exception = false)
 
       @test response.status == 404
       @test occursin("Sorry, we can not find", String(response.body)) == true
@@ -37,13 +38,14 @@
 
       server = up(port; open_browser = false)
 
-      response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/html"], status_exception = false)
+      client = HTTP.Client()
+      response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/html"], status_exception = false)
 
       @test response.status == 404
       @test occursin("Sorry, we can not find", String(response.body)) == true
       @test Dict(response.headers)["Content-Type"] == "text/html"
 
-      response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["AcCePt" => "text/html"], status_exception = false)
+      response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["AcCePt" => "text/html"], status_exception = false)
 
       @test response.status == 404
       @test occursin("Sorry, we can not find", String(response.body)) == true
@@ -64,13 +66,14 @@
 
       server = up(port; open_browser = false)
 
-      response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "application/json"], status_exception = false)
+      client = HTTP.Client()
+      response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "application/json"], status_exception = false)
 
       @test response.status == 404
       @test occursin("404 Not Found", String(response.body)) == true
       @test Dict(response.headers)["Content-Type"] == "application/json; charset=utf-8"
 
-      response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["CoNtEnt-TyPe" => "application/json"], status_exception = false)
+      response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["CoNtEnt-TyPe" => "application/json"], status_exception = false)
 
       @test response.status == 404
       @test occursin("404 Not Found", String(response.body)) == true
@@ -91,13 +94,14 @@
 
       server = up(port; open_browser = false)
 
-      response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "application/json"], status_exception = false)
+      client = HTTP.Client()
+      response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "application/json"], status_exception = false)
 
       @test response.status == 404
       @test occursin("404 Not Found", String(response.body)) == true
       @test Dict(response.headers)["Content-Type"] == "application/json; charset=utf-8"
 
-      response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["acCepT" => "application/json"], status_exception = false)
+      response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["acCepT" => "application/json"], status_exception = false)
 
       @test response.status == 404
       @test occursin("404 Not Found", String(response.body)) == true
@@ -118,13 +122,14 @@
 
       server = up(port; open_browser = false)
 
-      response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "text/plain"], status_exception = false)
+      client = HTTP.Client()
+      response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "text/plain"], status_exception = false)
 
       @test response.status == 404
       @test occursin("404 Not Found", String(response.body)) == true
       @test Dict(response.headers)["Content-Type"] == "text/plain"
 
-      response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["conTeNT-tYPE" => "text/plain"], status_exception = false)
+      response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["conTeNT-tYPE" => "text/plain"], status_exception = false)
 
       @test response.status == 404
       @test occursin("404 Not Found", String(response.body)) == true
@@ -146,13 +151,14 @@
 
     server = up(port; open_browser = false)
 
-    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "text/csv"], status_exception = false)
+    client = HTTP.Client()
+    response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "text/csv"], status_exception = false)
 
     @test response.status == 404
     @test occursin("404 Not Found", String(response.body)) == true
     @test Dict(response.headers)["Content-Type"] == "text/csv"
 
-    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["conTeNT-tYPE" => "text/csv"], status_exception = false)
+    response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["conTeNT-tYPE" => "text/csv"], status_exception = false)
 
     @test response.status == 404
     @test occursin("404 Not Found", String(response.body)) == true
@@ -173,13 +179,14 @@
 
     server = up(port; open_browser = false)
 
-    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/csv"], status_exception = false)
+    client = HTTP.Client()
+    response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/csv"], status_exception = false)
 
     @test response.status == 404
     @test occursin("404 Not Found", String(response.body)) == true
     @test Dict(response.headers)["Content-Type"] == "text/csv"
 
-    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["accEPT" => "text/csv"], status_exception = false)
+    response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["accEPT" => "text/csv"], status_exception = false)
 
     @test response.status == 404
     @test occursin("404 Not Found", String(response.body)) == true
@@ -200,7 +207,8 @@
 
     server = up(port; open_browser = false)
 
-    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "text/csv"], status_exception = false)
+    client = HTTP.Client()
+    response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "text/csv"], status_exception = false)
 
     @test response.status == 404
     @test occursin("404 Not Found", String(response.body)) == true
@@ -210,13 +218,13 @@
       HTTP.Response(401, ["Content-Type" => "text/csv"], body = "Search CSV and you shall find")
     end
 
-    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["conTeNT-tYPE" => "text/csv"], status_exception = false)
+    response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["conTeNT-tYPE" => "text/csv"], status_exception = false)
 
     @test response.status == 401
     @test occursin("Search CSV and you shall find", String(response.body)) == true
     @test Dict(response.headers)["Content-Type"] == "text/csv"
 
-    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["accept" => "text/csv"], status_exception = false)
+    response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["accept" => "text/csv"], status_exception = false)
 
     @test response.status == 401
     @test occursin("Search CSV and you shall find", String(response.body)) == true
@@ -237,7 +245,8 @@
 
     server = up(port; open_browser = false)
 
-    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "application/json"], status_exception = false)
+    client = HTTP.Client()
+    response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["Content-Type" => "application/json"], status_exception = false)
 
     @test response.status == 404
     @test occursin("404 Not Found", String(response.body)) == true
@@ -247,13 +256,13 @@
       HTTP.Response(401, ["Content-Type" => "application/json"], body = "Search CSV and you shall find")
     end
 
-    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["conTeNT-tYPE" => "application/json"], status_exception = false)
+    response = HTTP.request(client,"GET", "http://127.0.0.1:$port/notexisting", ["conTeNT-tYPE" => "application/json"], status_exception = false)
 
     @test response.status == 401
     @test occursin("Search CSV and you shall find", String(response.body)) == true
     @test Dict(response.headers)["Content-Type"] == "application/json"
 
-    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["accept" => "application/json"], status_exception = false)
+    response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["accept" => "application/json"], status_exception = false)
 
     @test response.status == 401
     @test occursin("Search CSV and you shall find", String(response.body)) == true
@@ -273,32 +282,33 @@
     port = rand(8500:8900)
 
     server = up(port; open_browser = false)
+    client = HTTP.Client()
 
-    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/html, text/plain, application/json, text/csv"], status_exception = false)
-
-    @test Dict(response.headers)["Content-Type"] == "text/html"
-
-    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/plain, application/json, text/csv, text/html"], status_exception = false)
-
-    @test Dict(response.headers)["Content-Type"] == "text/plain"
-
-    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "application/json, text/csv, text/html, text/plain"], status_exception = false)
-
-    @test Dict(response.headers)["Content-Type"] == "application/json"
-
-    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/csv, text/html, text/plain, application/json"], status_exception = false)
+    response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/html, text/plain, application/json, text/csv"], status_exception = false)
 
     @test Dict(response.headers)["Content-Type"] == "text/html"
 
-    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/csv, text/plain, application/json, text/html"], status_exception = false)
+    response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/plain, application/json, text/csv, text/html"], status_exception = false)
 
     @test Dict(response.headers)["Content-Type"] == "text/plain"
 
-    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/csv, application/json, text/html, text/plain"], status_exception = false)
+    response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "application/json, text/csv, text/html, text/plain"], status_exception = false)
 
     @test Dict(response.headers)["Content-Type"] == "application/json"
 
-    response = HTTP.request("GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/csv"], status_exception = false)
+    response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/csv, text/html, text/plain, application/json"], status_exception = false)
+
+    @test Dict(response.headers)["Content-Type"] == "text/html"
+
+    response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/csv, text/plain, application/json, text/html"], status_exception = false)
+
+    @test Dict(response.headers)["Content-Type"] == "text/plain"
+
+    response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/csv, application/json, text/html, text/plain"], status_exception = false)
+
+    @test Dict(response.headers)["Content-Type"] == "application/json"
+
+    response = HTTP.request(client, "GET", "http://127.0.0.1:$port/notexisting", ["Accept" => "text/csv"], status_exception = false)
 
     @test Dict(response.headers)["Content-Type"] == "text/csv"
 

--- a/test/tests_content_negotiation_hooks.jl
+++ b/test/tests_content_negotiation_hooks.jl
@@ -20,15 +20,16 @@
   port = rand(8500:8900)
 
   server = up(port)
+  client = HTTP.Client()
 
-  response = HTTP.request("GET", "http://localhost:$port")
+  response = HTTP.request(client, "GET", "http://localhost:$port")
   @test response.status == 200
   @test String(response.body) == original_message
 
 
   push!(Genie.Router.content_negotiation_hooks, hook)
 
-  response = HTTP.request("GET", "http://localhost:$port")
+  response = HTTP.request(client, "GET", "http://localhost:$port")
   @test response.status == 200
   @test String(response.body) == custom_message
 

--- a/test/tests_headers.jl
+++ b/test/tests_headers.jl
@@ -20,14 +20,15 @@
   port = rand(8500:8900)
 
   up(port; open_browser = false, verbose = true)
+  client = HTTP.Client()
 
-  response = HTTP.request("GET", "http://localhost:$port/headers") # unhandled, should get default response
+  response = HTTP.request(client, "GET", "http://localhost:$port/headers") # unhandled, should get default response
   @test response.status == 200
   @test String(response.body) == "OK"
   @test Dict(response.headers)["X-Foo-Bar"] == "Baz"
   @test get(Dict(response.headers), "Access-Control-Allow-Methods", nothing) == nothing
 
-  response = HTTP.request("OPTIONS", "http://localhost:$port/headers") # handled
+  response = HTTP.request(client, "OPTIONS", "http://localhost:$port/headers") # handled
   @test response.status == 200
   @test String(response.body) == "OOKK"
   @test Dict(response.headers)["X-Foo-Bar"] == "Bazinga"

--- a/test/tests_hello.jl
+++ b/test/tests_hello.jl
@@ -12,8 +12,9 @@
   port = rand(8500:8900)
 
   up(port)
-
-  response = HTTP.get("http://localhost:$port/hello")
+  client = HTTP.Client()
+  
+  response = HTTP.get(client, "http://localhost:$port/hello")
 
   @test response.status == 200
   @test String(response.body) == message

--- a/test/tests_json_encodings.jl
+++ b/test/tests_json_encodings.jl
@@ -15,26 +15,27 @@
   port = rand(8500:8900)
 
   server = up(port)
+  client = HTTP.Client()
 
-  response = HTTP.request("POST", "http://localhost:$port/jsonpayload",
+  response = HTTP.request(client, "POST", "http://localhost:$port/jsonpayload",
                   [("Content-Type", "application/json; charset=utf-8")], """{"greeting":"hello"}""")
 
   @test response.status == 200
   @test String(response.body) |> fws == """Dict{String, Any}("greeting" => "hello")""" |> fws
 
-  response = HTTP.request("POST", "http://localhost:$port/jsongreeting",
+  response = HTTP.request(client, "POST", "http://localhost:$port/jsongreeting",
                   [("Content-Type", "application/json")], """{"greeting":"hello"}""")
 
   @test response.status == 200
   @test String(response.body) |> fws == """hello""" |> fws
 
-  response = HTTP.request("POST", "http://localhost:$port/jsonpayload",
+  response = HTTP.request(client, "POST", "http://localhost:$port/jsonpayload",
                   [("Content-Type", "application/json")], """{"greeting":"hello"}""")
 
   @test response.status == 200
   @test String(response.body) |> fws == """Dict{String, Any}("greeting" => "hello")""" |> fws
 
-  response = HTTP.request("POST", "http://localhost:$port/jsongreeting",
+  response = HTTP.request(client, "POST", "http://localhost:$port/jsongreeting",
                   [("Content-Type", "application/json; charset=utf-8")], """{"greeting":"hello"}""")
 
   @test response.status == 200
@@ -42,25 +43,25 @@
 
   #===#
 
-  response = HTTP.request("POST", "http://localhost:$port/jsonpayload",
+  response = HTTP.request(client, "POST", "http://localhost:$port/jsonpayload",
                   [("Content-Type", "application/vnd.api+json; charset=utf-8")], """{"greeting":"hello"}""")
 
   @test response.status == 200
   @test String(response.body) |> fws == """Dict{String, Any}("greeting" => "hello")""" |> fws
 
-  response = HTTP.request("POST", "http://localhost:$port/jsongreeting",
+  response = HTTP.request(client, "POST", "http://localhost:$port/jsongreeting",
                   [("Content-Type", "application/vnd.api+json; charset=utf-8")], """{"greeting":"hello"}""")
 
   @test response.status == 200
   @test String(response.body) |> fws == """hello""" |> fws
 
-  response = HTTP.request("POST", "http://localhost:$port/jsonpayload",
+  response = HTTP.request(client, "POST", "http://localhost:$port/jsonpayload",
                   [("Content-Type", "application/vnd.api+json")], """{"greeting":"hello"}""")
 
   @test response.status == 200
   @test String(response.body) |> fws == """Dict{String, Any}("greeting" => "hello")""" |> fws
 
-  response = HTTP.request("POST", "http://localhost:$port/jsongreeting",
+  response = HTTP.request(client, "POST", "http://localhost:$port/jsongreeting",
                   [("Content-Type", "application/vnd.api+json")], """{"greeting":"hello"}""")
 
   @test response.status == 200

--- a/test/tests_json_payload.jl
+++ b/test/tests_json_payload.jl
@@ -18,7 +18,7 @@
   
   function roundtrip(x)
     global json_result
-    HTTP.request("POST",
+    HTTP.request(client, "POST",
       "http://localhost:$port/jsonroundtrip",
       [("Content-Type", "application/json")],
       Genie.JSONParser.json(Dict(:payload => x))
@@ -29,26 +29,27 @@
   port = rand(8500:8900)
 
   server = up(port)
+  client = HTTP.Client()
 
-  response = HTTP.request("POST", "http://localhost:$port/jsonpayload",
+  response = HTTP.request(client, "POST", "http://localhost:$port/jsonpayload",
                   [("Content-Type", "application/json; charset=utf-8")], """{"greeting":"hello"}""")
 
   @test response.status == 200
   @test String(response.body) |> fws == """Dict{String, Any}("greeting" => "hello")""" |> fws
 
-  response = HTTP.request("POST", "http://localhost:$port/jsontest",
+  response = HTTP.request(client, "POST", "http://localhost:$port/jsontest",
                   [("Content-Type", "application/json; charset=utf-8")], """{"test":[1,2,3]}""")
 
   @test response.status == 200
   @test String(response.body) == "[1, 2, 3]"
 
-  response = HTTP.request("POST", "http://localhost:$port/jsonpayload",
+  response = HTTP.request(client, "POST", "http://localhost:$port/jsonpayload",
                   [("Content-Type", "application/json")], """{"greeting":"hello"}""")
 
   @test response.status == 200
   @test String(response.body) |> fws == """Dict{String, Any}("greeting" => "hello")""" |> fws
 
-  response = HTTP.request("POST", "http://localhost:$port/jsontest",
+  response = HTTP.request(client, "POST", "http://localhost:$port/jsontest",
                   [("Content-Type", "application/json")], """{"test":[1,2,3]}""")
 
   @test response.status == 200
@@ -62,7 +63,7 @@
     error("500, sorry")
   end
 
-  @test_throws HTTP.StatusError HTTP.request("POST", "http://localhost:$port/json-error", [("Content-Type", "application/json; charset=utf-8")], """{"greeting":"hello"}""")
+  @test_throws HTTP.StatusError HTTP.request(client, "POST", "http://localhost:$port/json-error", [("Content-Type", "application/json; charset=utf-8")], """{"greeting":"hello"}""")
 
   down()
   sleep(1)

--- a/test/tests_options_request.jl
+++ b/test/tests_options_request.jl
@@ -10,13 +10,14 @@
   port = rand(8500:8900)
 
   server = up(port)
+  client = HTTP.Client()
   sleep(1)
 
-  response = HTTP.request("OPTIONS", "http://localhost:$port") # unhandled, should get default response
+  response = HTTP.request(client, "OPTIONS", "http://localhost:$port") # unhandled, should get default response
   @test response.status == 200
   @test get(Dict(response.headers), "X-Foo-Bar", nothing) == nothing
 
-  response = HTTP.request("OPTIONS", "http://localhost:$port/options") # handled
+  response = HTTP.request(client, "OPTIONS", "http://localhost:$port/options") # handled
   @test response.status == 200
   @test get(Dict(response.headers), "X-Foo-Bar", nothing) == "Baz"
 

--- a/test/tests_pathtraversal.jl
+++ b/test/tests_pathtraversal.jl
@@ -8,11 +8,12 @@
 
     port = rand(8000:10_000)
     server = up(port)
+    client = HTTP.Client()
 
-    req = HTTP.request("GET", "http://localhost:$port////etc/hosts"; status_exception = false)
+    req = HTTP.request(client, "GET", "http://localhost:$port////etc/hosts"; status_exception = false)
     @test req.status == (Sys.iswindows() ? 404 : 401)
 
-    # req = HTTP.request("GET", "http://localhost:$port/../../src/mimetypes.jl"; status_exception = false)
+    # req = HTTP.request(client, "GET", "http://localhost:$port/../../src/mimetypes.jl"; status_exception = false)
     # @test req.status == 401
 
     Genie.Server.down!()
@@ -28,10 +29,10 @@
 
   #   port = rand(8000:10_000)
   #   server = Genie.Server.serve(; port)
-  #   req = HTTP.request("GET", "http://localhost:$port//etc/passwd"; status_exception = false)
+  #   req = HTTP.request(client, "GET", "http://localhost:$port//etc/passwd"; status_exception = false)
   #   @test req.status == (Sys.iswindows() ? 404 : 401)
 
-  #   req = HTTP.request("GET", "http://localhost:$port/../../src/mimetypes.jl"; status_exception = false)
+  #   req = HTTP.request(client, "GET", "http://localhost:$port/../../src/mimetypes.jl"; status_exception = false)
   #   @test req.status == 401
 
   #   Genie.Server.down!()

--- a/test/tests_peer_info.jl
+++ b/test/tests_peer_info.jl
@@ -10,9 +10,10 @@
     end
 
     server = up(port)
+    client = HTTP.Client()
 
     response = try
-      HTTP.request("GET", "http://127.0.0.1:$port")
+      HTTP.request(client, "GET", "http://127.0.0.1:$port")
     catch ex
       ex.response
     end
@@ -31,9 +32,10 @@
     end
 
     server = up(port)
+    client = HTTP.Client()
 
     response = try
-      HTTP.request("GET", "http://127.0.0.1:$port")
+      HTTP.request(client, "GET", "http://127.0.0.1:$port")
     catch ex
       ex.response
     end

--- a/test/tests_post_data.jl
+++ b/test/tests_post_data.jl
@@ -19,32 +19,33 @@
   port = rand(8500:8900)
 
   up(port; open_browser = false)
+  client = HTTP.Client()
 
-  response = HTTP.request("POST", "http://localhost:$port/", ["Content-Type" => "application/x-www-form-urlencoded"], "greeting=Hello")
+  response = HTTP.request(client, "POST", "http://localhost:$port/", ["Content-Type" => "application/x-www-form-urlencoded"], "greeting=Hello")
   @test response.status == 200
   @test String(response.body) == "Hello"
 
-  response = HTTP.request("POST", "http://localhost:$port/", ["Content-Type" => "application/x-www-form-urlencoded"], "greeting=Hey you there")
+  response = HTTP.request(client, "POST", "http://localhost:$port/", ["Content-Type" => "application/x-www-form-urlencoded"], "greeting=Hey you there")
   @test response.status == 200
   @test String(response.body) == "Hey you there"
 
-  response = HTTP.request("GET", "http://localhost:$port/", ["Content-Type" => "application/x-www-form-urlencoded"], "greeting=Hello")
+  response = HTTP.request(client, "GET", "http://localhost:$port/", ["Content-Type" => "application/x-www-form-urlencoded"], "greeting=Hello")
   @test response.status == 200
   @test String(response.body) == "GET"
 
-  response = HTTP.request("POST", "http://localhost:$port/data", ["Content-Type" => "application/x-www-form-urlencoded"], "fields%5B%5D=Hey you there&fields%5B%5D=&single=")
+  response = HTTP.request(client, "POST", "http://localhost:$port/data", ["Content-Type" => "application/x-www-form-urlencoded"], "fields%5B%5D=Hey you there&fields%5B%5D=&single=")
   @test response.status == 200
   @test String(response.body) == "Hey you there"
 
-  response = HTTP.request("POST", "http://localhost:$port/data", ["Content-Type" => "application/x-www-form-urlencoded"], "fields%5B%5D=1&fields%5B%5D=2&single=3")
+  response = HTTP.request(client, "POST", "http://localhost:$port/data", ["Content-Type" => "application/x-www-form-urlencoded"], "fields%5B%5D=1&fields%5B%5D=2&single=3")
   @test response.status == 200
   @test String(response.body) == "123"
 
-  response = HTTP.post("http://localhost:$port", [], HTTP.Form(Dict("greeting" => "Hello")))
+  response = HTTP.post(client, "http://localhost:$port", [], HTTP.Form(Dict("greeting" => "Hello")))
   @test response.status == 200
   @test String(response.body) == "Hello"
 
-  response = HTTP.post("http://localhost:$port", [], HTTP.Form(Dict("greeting" => "Hey you there")))
+  response = HTTP.post(client, "http://localhost:$port", [], HTTP.Form(Dict("greeting" => "Hey you there")))
   @test response.status == 200
   @test String(response.body) == "Hey you there"
   

--- a/test/tests_query_params.jl
+++ b/test/tests_query_params.jl
@@ -15,9 +15,10 @@
   end
 
   server = up(port)
+  client = HTTP.Client()
 
   response = try
-    HTTP.request("GET", "http://127.0.0.1:$port", ["Content-Type" => "text/html"])
+    HTTP.request(client, "GET", "http://127.0.0.1:$port", ["Content-Type" => "text/html"])
   catch ex
     ex.response
   end
@@ -44,9 +45,10 @@ end
   end
 
   server = up(port)
+  client = HTTP.Client()
 
   response = try
-    HTTP.request("GET", "http://127.0.0.1:$port", ["Content-Type" => "text/html"])
+    HTTP.request(client, "GET", "http://127.0.0.1:$port", ["Content-Type" => "text/html"])
   catch ex
     ex.response
   end
@@ -72,11 +74,12 @@ end
   end
 
   server = up(port)
+  client = HTTP.Client()
 
   # ====
 
   response = try
-    HTTP.request("GET", "http://127.0.0.1:$port", ["Content-Type" => "text/html"])
+    HTTP.request(client, "GET", "http://127.0.0.1:$port", ["Content-Type" => "text/html"])
   catch ex
     ex.response
   end
@@ -87,7 +90,7 @@ end
   # ====
 
   response = try
-    HTTP.request("GET", "http://127.0.0.1:$port/?", ["Content-Type" => "text/html"])
+    HTTP.request(client, "GET", "http://127.0.0.1:$port/?", ["Content-Type" => "text/html"])
   catch ex
     ex.response
   end
@@ -98,7 +101,7 @@ end
   # ====
 
   response = try
-    HTTP.request("GET", "http://127.0.0.1:$port/?x", ["Content-Type" => "text/html"])
+    HTTP.request(client, "GET", "http://127.0.0.1:$port/?x", ["Content-Type" => "text/html"])
   catch ex
     ex.response
   end
@@ -109,7 +112,7 @@ end
   # ====
 
   response = try
-    HTTP.request("GET", "http://127.0.0.1:$port/?x&a=3", ["Content-Type" => "text/html"])
+    HTTP.request(client, "GET", "http://127.0.0.1:$port/?x&a=3", ["Content-Type" => "text/html"])
   catch ex
     ex.response
   end
@@ -120,7 +123,7 @@ end
   # ====
 
   response = try
-    HTTP.request("GET", "http://127.0.0.1:$port/?x&y", ["Content-Type" => "text/html"])
+    HTTP.request(client, "GET", "http://127.0.0.1:$port/?x&y", ["Content-Type" => "text/html"])
   catch ex
     ex.response
   end
@@ -147,9 +150,10 @@ end
   end
 
   server = up(port)
+  client = HTTP.Client()
 
   response = try
-    HTTP.request("GET", "http://127.0.0.1:$port?x=1", ["Content-Type" => "text/html"])
+    HTTP.request(client, "GET", "http://127.0.0.1:$port?x=1", ["Content-Type" => "text/html"])
   catch ex
     ex.response
   end
@@ -160,7 +164,7 @@ end
   # ====
 
   response = try
-    HTTP.request("GET", "http://127.0.0.1:$port?x=1&x=2", ["Content-Type" => "text/html"])
+    HTTP.request(client, "GET", "http://127.0.0.1:$port?x=1&x=2", ["Content-Type" => "text/html"])
   catch ex
     ex.response
   end
@@ -171,7 +175,7 @@ end
   # ====
 
   response = try
-    HTTP.request("GET", "http://127.0.0.1:$port?x=1&x=2&x=3", ["Content-Type" => "text/html"])
+    HTTP.request(client, "GET", "http://127.0.0.1:$port?x=1&x=2&x=3", ["Content-Type" => "text/html"])
   catch ex
     ex.response
   end
@@ -182,7 +186,7 @@ end
   # ====
 
   response = try
-    HTTP.request("GET", "http://127.0.0.1:$port?x=1&x=2&x=3&y=0", ["Content-Type" => "text/html"])
+    HTTP.request(client, "GET", "http://127.0.0.1:$port?x=1&x=2&x=3&y=0", ["Content-Type" => "text/html"])
   catch ex
     ex.response
   end
@@ -193,7 +197,7 @@ end
   # ====
 
   response = try
-    HTTP.request("GET", "http://127.0.0.1:$port?x=0&x[]=1&x[]=2", ["Content-Type" => "text/html"])
+    HTTP.request(client, "GET", "http://127.0.0.1:$port?x=0&x[]=1&x[]=2", ["Content-Type" => "text/html"])
   catch ex
     ex.response
   end
@@ -220,11 +224,13 @@ end
   end
 
   server = up(port)
+  client = HTTP.Client()
+  client = HTTP.Client()
 
   # ====
 
   response = try
-    HTTP.request("GET", "http://127.0.0.1:$port", ["Content-Type" => "text/html"])
+    HTTP.request(client, "GET", "http://127.0.0.1:$port", ["Content-Type" => "text/html"])
   catch ex
     ex.response
   end
@@ -235,7 +241,7 @@ end
   # ====
 
   response = try
-    HTTP.request("GET", "http://127.0.0.1:$port/?x&x[]=1000", ["Content-Type" => "text/html"])
+    HTTP.request(client, "GET", "http://127.0.0.1:$port/?x&x[]=1000", ["Content-Type" => "text/html"])
   catch ex
     ex.response
   end
@@ -246,7 +252,7 @@ end
   # ====
 
   response = try
-    HTTP.request("GET", "http://127.0.0.1:$port/?x&x[]=1000&x[]=2000", ["Content-Type" => "text/html"])
+    HTTP.request(client, "GET", "http://127.0.0.1:$port/?x&x[]=1000&x[]=2000", ["Content-Type" => "text/html"])
   catch ex
     ex.response
   end
@@ -257,7 +263,7 @@ end
   # ====
 
   response = try
-    HTTP.request("GET", "http://127.0.0.1:$port/?x=9&x[]=1000&x[]=2000", ["Content-Type" => "text/html"])
+    HTTP.request(client, "GET", "http://127.0.0.1:$port/?x=9&x[]=1000&x[]=2000", ["Content-Type" => "text/html"])
   catch ex
     ex.response
   end
@@ -268,7 +274,7 @@ end
   # ====
 
   response = try
-    HTTP.request("GET", "http://127.0.0.1:$port/?x=9&x[]=1000&x[]=2000&y[]=8", ["Content-Type" => "text/html"])
+    HTTP.request(client, "GET", "http://127.0.0.1:$port/?x=9&x[]=1000&x[]=2000&y[]=8", ["Content-Type" => "text/html"])
   catch ex
     ex.response
   end

--- a/test/tests_query_special_chars.jl
+++ b/test/tests_query_special_chars.jl
@@ -11,9 +11,10 @@
     end
 
     server = up(port)
+    client = HTTP.Client()
 
     response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/?x=foo+bar")
+      HTTP.request(client, "GET", "http://127.0.0.1:$port/?x=foo+bar")
     catch ex
       ex.response
     end
@@ -39,9 +40,10 @@
     end
 
     server = up(port)
+    client = HTTP.Client()
 
     response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/?x=foo%20bar")
+      HTTP.request(client, "GET", "http://127.0.0.1:$port/?x=foo%20bar")
     catch ex
       ex.response
     end
@@ -67,9 +69,10 @@
     end
 
     server = up(port)
+    client = HTTP.Client()
 
     response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/?x=foo%2Bbar")
+      HTTP.request(client, "GET", "http://127.0.0.1:$port/?x=foo%2Bbar")
     catch ex
       ex.response
     end
@@ -95,9 +98,10 @@
     end
 
     server = up(port)
+    client = HTTP.Client()
 
     response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/?x=✔+🧞+♥")
+      HTTP.request(client, "GET", "http://127.0.0.1:$port/?x=✔+🧞+♥")
     catch ex
       ex.response
     end

--- a/test/tests_responses.jl
+++ b/test/tests_responses.jl
@@ -17,8 +17,9 @@
   port = rand(8500:8900)
 
   server = up(port)
+  client = HTTP.Client()
 
-  response = HTTP.request("GET", "http://localhost:$port/responses")
+  response = HTTP.request(client, "GET", "http://localhost:$port/responses")
   @test response.status == 301
   @test Dict(response.headers)["X-Foo-Bar"] == "Baz"
   @test Dict(response.headers)["X-A-B"] == "C"
@@ -27,7 +28,7 @@
   # In HTTP.jl v2, the body is correctly a String, not Vector{Char}
   @test String(response.body) == "Hello"
 
-  @test_throws HTTP.StatusError HTTP.request("GET", "http://localhost:$port/broken", ["Content-Type"=>"text/plain"])
+  @test_throws HTTP.StatusError HTTP.request(client, "GET", "http://localhost:$port/broken", ["Content-Type"=>"text/plain"])
 
   down()
   sleep(1)

--- a/test/tests_routing.jl
+++ b/test/tests_routing.jl
@@ -12,9 +12,10 @@
     end
 
     server = up(port)
+    client = HTTP.Client()
 
     response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/✔/🧞/♥/❤")
+      HTTP.request(client, "GET", "http://127.0.0.1:$port/✔/🧞/♥/❤")
     catch ex
       ex.response
     end
@@ -39,9 +40,10 @@
     end
 
     server = up(port)
+    client = HTTP.Client()
 
     response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/✔")
+      HTTP.request(client, "GET", "http://127.0.0.1:$port/✔")
     catch ex
       ex.response
     end
@@ -67,9 +69,10 @@
     end
 
     server = up(port)
+    client = HTTP.Client()
 
     response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/réception")
+      HTTP.request(client, "GET", "http://127.0.0.1:$port/réception")
     catch ex
       ex.response
     end
@@ -95,9 +98,10 @@
     end
 
     server = up(port)
+    client = HTTP.Client()
 
     response = try
-      HTTP.request("GET", "http://127.0.0.1:$port/✔/🧞/♥/❤")
+      HTTP.request(client, "GET", "http://127.0.0.1:$port/✔/🧞/♥/❤")
     catch ex
       ex.response
     end

--- a/test/tests_z_HEAD_requests.jl
+++ b/test/tests_z_HEAD_requests.jl
@@ -11,9 +11,10 @@
     end
 
     server = up(port)
+    client = HTTP.Client()
 
     response = try
-      HTTP.request("GET", "http://127.0.0.1:$port", ["Content-Type" => "text/html"])
+      HTTP.request(client, "GET", "http://127.0.0.1:$port", ["Content-Type" => "text/html"])
     catch ex
       ex.response
     end
@@ -22,7 +23,7 @@
     @test String(response.body) == "GET request"
 
     response = try
-      HTTP.request("HEAD", "http://127.0.0.1:$port", ["Content-Type" => "text/html"])
+      HTTP.request(client, "HEAD", "http://127.0.0.1:$port", ["Content-Type" => "text/html"])
     catch ex
       ex.response
     end
@@ -52,9 +53,10 @@
     end
 
     server = up(port; open_browser = false)
+    client = HTTP.Client()
 
     response = try
-      HTTP.request("GET", "http://127.0.0.1:$port", ["Content-Type" => "text/html"])
+      HTTP.request(client, "GET", "http://127.0.0.1:$port", ["Content-Type" => "text/html"])
     catch ex
       ex.response
     end
@@ -63,7 +65,7 @@
     @test String(response.body) == "Hello world"
 
     response = try
-      HTTP.request("HEAD", "http://127.0.0.1:$port", ["Content-Type" => "text/html"])
+      HTTP.request(client, "HEAD", "http://127.0.0.1:$port", ["Content-Type" => "text/html"])
     catch ex
       ex.response
     end
@@ -96,10 +98,11 @@
     end
 
     server = up(port)
+    client = HTTP.Client()
     sleep(1)
 
     response = try
-      HTTP.request("GET", "http://127.0.0.1:$port", ["Content-Type" => "text/html"])
+      HTTP.request(client, "GET", "http://127.0.0.1:$port", ["Content-Type" => "text/html"])
     catch ex
       ex.response
     end
@@ -108,7 +111,7 @@
     @test request_method[] == "GET"
 
     response = try
-      HTTP.request("HEAD", "http://127.0.0.1:$port", ["Content-Type" => "text/html"])
+      HTTP.request(client, "HEAD", "http://127.0.0.1:$port", ["Content-Type" => "text/html"])
     catch ex
       ex.response
     end

--- a/test/tests_zz_fullstack_app.jl
+++ b/test/tests_zz_fullstack_app.jl
@@ -8,6 +8,7 @@
     using Pkg
 
     using Genie
+    import HTTP
 
     content = "Test OK!"
 
@@ -32,9 +33,10 @@
     end
 
     up(9999)
+    client = HTTP.Client()
     sleep(10)
 
-    r = Genie.Requests.HTTP.request("GET", "http://localhost:9999/test")
+    r = HTTP.request(client, "GET", "http://localhost:9999/test")
 
     @test occursin(content, String(r.body)) == true
 

--- a/test/tests_zzz_dotenv.jl
+++ b/test/tests_zzz_dotenv.jl
@@ -38,7 +38,7 @@
 
     # sleep(10)
 
-    # r = Genie.Requests.HTTP.request("GET", "http://$(ENV["HOST"]):$(ENV["PORT"])/")
+    # r = Genie.Requests.HTTP.request(client, "GET", "http://$(ENV["HOST"]):$(ENV["PORT"])/")
     # @test r.status == Genie.Router.OK
 
     # eobj = Genie.JSONParser.parse(String(r.body))


### PR DESCRIPTION
This is a test to see whether encapsulating requests via `client = HTTP.client()` can eliminate the segfaulting of julia 1.10 during tests.
The root cause of the segfaulting should probably be solved in HTTP (currently at version 2.6.6)